### PR TITLE
Fixing issue when subclassing models

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -85,7 +85,7 @@ class TaggableManager(RelatedField):
         self.rel.to = self.through._meta.get_field("tag").rel.to
         if self.use_gfk:
             tagged_items = GenericRelation(self.through)
-            tagged_items.contribute_to_class(cls, "tagged_items")
+            tagged_items.contribute_to_class(cls, "%s_tagged_items" % cls.__name__.lower())
 
     def save_form_data(self, instance, value):
         getattr(instance, self.name).set(*value)


### PR DESCRIPTION
This change creates related names that contain the class name, so that related names won't clash when subclassing taggit models.