### PR TITLE
Don't return extra fields for joins resolved through other managers.

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -129,7 +129,7 @@ class TaggableManager(RelatedField):
         return self.through._meta.db_table
 
     def extra_filters(self, pieces, pos, negate):
-        if negate or not self.use_gfk:
+        if negate or not self.use_gfk or (len(pieces) and self.name != pieces[0]):
             return []
         prefix = "__".join(["tagged_items"] + pieces[:pos-2])
         cts = map(ContentType.objects.get_for_model, _get_subclasses(self.model))


### PR DESCRIPTION
This *might* be a fix for #84. I had a query that required me to do `taggedmodel__tags__name__in` in my filters, which would trigger this `extra_filters()` bug in #84. My fix simply says, "Is the first piece of this filter me?" If the answer is no, then `extra_filters()` is entirely skipped.

I'm not well versed in the ORM internals so I can't be 100% sure this is a firm fix. What I can say is that it's likely a safer fix than entirely removing `extra_filters()`. I also don't have a test for this; sorry about that!