### PR TITLE
Add option to override default tag string parsing

### DIFF
--- a/docs/custom_tagging.txt
+++ b/docs/custom_tagging.txt
@@ -1,6 +1,8 @@
-Using a Custom Tag or Through Model
-===================================
+Customizing taggit
+==================
 
+Using a Custom Tag or Through Model
+-----------------------------------
 By default ``django-taggit`` uses a "through model" with a
 ``GenericForeignKey`` on it, that has another ``ForeignKey`` to an included
 ``Tag`` model.  However, there are some cases where this isn't desirable, for
@@ -165,3 +167,35 @@ model named ``"tag"``:
         signifies how many times the slug for this tag has been attempted to be
         calculated, it is ``None`` on the first time, and the counting begins
         at ``1`` thereafter.
+
+
+Using a custom tag string parser
+--------------------------------
+By default ``django-taggit`` uses :func:`taggit.utils._parse_tags` which
+accepts a string which may contain one or more tags and returns a list of tag
+names.  This parser is quite intelligent and can handle a number of edge cases;
+however, you may wish to provide your own parser for various reasons (e.g. you
+can do some preprocessing on the tags so that they are converted to lowercase,
+reject certain tags, disallow certain characters, split only on commas rather
+than commas and whitespace, etc.).  To provide your own parser, write a
+function that takes a tag string and returns a list of tag names.  For example,
+a simple function to split on comma and convert to lowercase::
+
+    def comma_splitter(tag_string):
+        return [t.strip().lower() for t in tag_string.split(',') if t.strip()]
+
+You need to tell ``taggit`` to use this function instead of the default by
+adding a new setting, ``TAGGIT_TAGS_FROM_STRING`` and providing it with the
+dotted path to your function.  Likewise, you can provide a function to convert
+a list of tags to a string representation and use the setting
+``TAGGIT_STRING_FROM_TAGS`` to override the default value (which is
+:func:`taggit.utils._edit_string_for_tags`)::
+
+    def comma_joiner(tag_string):
+        return ', '.join(t.name for t in tags)
+
+If the functions above were defined in a module, ``appname.utils``, then your
+project settings.py file should contain the following::
+
+    TAGGIT_TAGS_FROM_STRING = 'appname.utils.comma_splitter'
+    TAGGIT_STRING_FROM_TAGS = 'appname.utils.comma_joiner'

--- a/taggit/utils.py
+++ b/taggit/utils.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
+from importlib import import_module
+
 from django import VERSION
+from django.conf import settings
 from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.functional import wraps
@@ -13,7 +16,7 @@ def _get_field(model, name):
         return model._meta.get_field(name)
 
 
-def parse_tags(tagstring):
+def _parse_tags(tagstring):
     """
     Parses tag input, with multiple word input being activated and
     delineated by commas and double quotes. Quotes take precedence, so
@@ -102,7 +105,7 @@ def split_strip(string, delimiter=','):
     return [w for w in words if w]
 
 
-def edit_string_for_tags(tags):
+def _edit_string_for_tags(tags):
     """
     Given list of ``Tag`` instances, creates a string representation of
     the list suitable for editing by the user, such that submitting the
@@ -135,3 +138,30 @@ def require_instance_manager(func):
             raise TypeError("Can't call %s with a non-instance manager" % func.__name__)
         return func(self, *args, **kwargs)
     return inner
+
+
+def get_func(key, default):
+    func_path = getattr(settings, key, default)
+    try:
+        return get_func.cache[func_path]
+    except KeyError:
+        mod_path, func_name = func_path.rsplit('.', 1)
+        func = getattr(import_module(mod_path), func_name)
+        get_func.cache[func_path] = func
+        return func
+
+# Create a cache as an attribute on the function that way it can cache the
+# imported callable rather than re-importing it each time `parse_tags` or
+# `edit_string_for_tags` needs the callable.
+get_func.cache = {}
+
+
+def parse_tags(tagstring):
+    func = get_func('TAGGIT_TAGS_FROM_STRING', 'taggit.utils._parse_tags')
+    return func(tagstring)
+
+
+def edit_string_for_tags(tags):
+    func = get_func('TAGGIT_STRING_FROM_TAGS',
+                    'taggit.utils._edit_string_for_tags')
+    return func(tags)

--- a/tests/custom_parser.py
+++ b/tests/custom_parser.py
@@ -1,0 +1,5 @@
+def comma_splitter(tag_string):
+    return [t.strip() for t in tag_string.split(',') if t.strip()]
+
+def comma_joiner(tags):
+    return ', '.join(t.name for t in tags)


### PR DESCRIPTION
To provide some flexibility in parsing tag strings and creating tag strings from a list of tags, users can now provide their own functions for performing these operations.  Fixes #215.

This is per the discussion in #215.  Please let me know if there's anything else that needs to be fixed before you'll accept the PR.