### PR TITLE
add the min_count parameter to managers.most_common function

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -42,6 +42,8 @@ playing around with the API.
         ``QuerySet``is ordered by ``num_times``, descending.  The ``QuerySet``
         is lazily evaluated, and can be sliced efficiently.
 
+        :param min_count: Specify a min count to limit the returned queryset
+
     .. method:: similar_objects()
 
         Returns a list (not a lazy ``QuerySet``) of other objects tagged

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -169,10 +169,14 @@ class _TaggableManager(models.Manager):
     def clear(self):
         self.through.objects.filter(**self._lookup_kwargs()).delete()
 
-    def most_common(self):
-        return self.get_queryset().annotate(
+    def most_common(self, min_count=None):
+        queryset = self.get_queryset().annotate(
             num_times=models.Count(self.through.tag_relname())
         ).order_by('-num_times')
+        if min_count:
+            queryset = queryset.filter(num_times__gte=min_count)
+
+        return queryset
 
     @require_instance_manager
     def similar_objects(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -130,6 +130,12 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             sort=False
         )
 
+        self.assert_tags_equal(
+            self.food_model.tags.most_common(min_count=2),
+            ['green'],
+            sort=False
+        )
+
         apple.tags.remove('green')
         self.assert_tags_equal(apple.tags.all(), ['red'])
         self.assert_tags_equal(self.food_model.tags.all(), ['green', 'red'])


### PR DESCRIPTION
If ``min_count`` is given, only tags which have a ``num_times`` greater than or equal to ``min_count`` will be returned.