### PR TITLE
Add case-insensitive option for tag names.

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -4,6 +4,7 @@ from operator import attrgetter
 
 from django import VERSION
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
 from django.db import models, router
 from django.db.models.fields import Field
 from django.db.models.fields.related import (add_lazy_relation, ManyToManyRel,
@@ -144,14 +145,30 @@ class _TaggableManager(models.Manager):
                 raise ValueError("Cannot add {0} ({1}). Expected {2} or str.".format(
                     t, type(t), type(self.through.tag_model())))
 
-        # If str_tags has 0 elements Django actually optimizes that to not do a
-        # query.  Malcolm is very smart.
-        existing = self.through.tag_model().objects.filter(
-            name__in=str_tags
-        )
+        if getattr(settings, 'TAGGIT_CASE_INSENSITIVE', False):
+            # Some databases can do case-insensitive comparison with IN, which
+            # would be faster, but we can't rely on it or easily detect it.
+            existing = []
+            tags_to_create = []
+
+            for name in str_tags:
+                try:
+                    tag = self.through.tag_model().objects.get(name__iexact=name)
+                    existing.append(tag)
+                except self.through.tag_model().DoesNotExist:
+                    tags_to_create.append(name)
+        else:
+            # If str_tags has 0 elements Django actually optimizes that to not do a
+            # query.  Malcolm is very smart.
+            existing = self.through.tag_model().objects.filter(
+                name__in=str_tags
+            )
+
+            tags_to_create = str_tags - set(t.name for t in existing)
+
         tag_objs.update(existing)
 
-        for new_tag in str_tags - set(t.name for t in existing):
+        for new_tag in tags_to_create:
             tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
 
         for tag in tag_objs:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.test import TestCase, TransactionTestCase
+from django.test.utils import override_settings
 from django.utils.encoding import force_text
 
 from .forms import CustomPKFoodForm, DirectFoodForm, FoodForm, OfficialFoodForm
@@ -367,6 +368,14 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 'orange': set(['2', '4']),
                 'apple': set(['1', '2'])
             })
+
+    @override_settings(TAGGIT_CASE_INSENSITIVE=True)
+    def test_with_case_insensitive_option(self):
+        spain = self.tag_model.objects.create(name="Spain", slug="spain")
+        orange = self.food_model.objects.create(name="orange")
+        orange.tags.add('spain')
+        self.assertEqual(list(orange.tags.all()), [spain])
+
 
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     food_model = DirectFood


### PR DESCRIPTION
I don't think it makes sense to have tags which differ only in case. It's not even possible on MySQL because it violates the unique constraint on tag name:

    IntegrityError: (1062, "Duplicate entry 'LONDON' for key 'taggit_tag_name_6b48d50f_uniq'")

This PR adds a new setting, `TAGGIT_CASE_INSENSITIVE`, which causes existing tags to be looked up case insensitively. New tags are added with the supplied case, which will be used from then on. The default behaviour is the same as before without this setting.

This meets nookiepl's request on #70, and my comment on #9.