### PR TITLE
Fix joins on taggable managers defined on submodels of multi-table inheritance.

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -447,10 +447,8 @@ class TaggableManager(RelatedField, Field):
             return self._get_mm_case_path_info(direct=False)
 
     def get_joining_columns(self, reverse_join=False):
-        if reverse_join:
-            return (("id", "object_id"),)
-        else:
-            return (("object_id", "id"),)
+        source = self.reverse_related_fields if reverse_join else self.related_fields
+        return tuple([(lhs_field.column, rhs_field.column) for lhs_field, rhs_field in source])
 
     def get_extra_restriction(self, where_class, alias, related_alias):
         extra_col = self.through._meta.get_field_by_name('content_type')[0].column
@@ -465,6 +463,10 @@ class TaggableManager(RelatedField, Field):
     def related_fields(self):
         return [(self.through._meta.get_field_by_name('object_id')[0],
                  self.model._meta.pk)]
+
+    @property
+    def reverse_related_fields(self):
+        return [(rhs_field, lhs_field) for lhs_field, rhs_field in self.related_fields]
 
     @property
     def foreign_related_fields(self):

--- a/tests/migrations/0002_submodelmanagerpet_submodelmanagerhousepet.py
+++ b/tests/migrations/0002_submodelmanagerpet_submodelmanagerhousepet.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
-            name='SubmodelManegerHousePet',
+            name='SubmodelManagerHousePet',
             fields=[
                 ('submodelmanagerpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.SubmodelManagerPet')),
                 ('trained', models.BooleanField(default=False)),

--- a/tests/migrations/0002_submodelmanagerpet_submodelmanegerhousepet.py
+++ b/tests/migrations/0002_submodelmanagerpet_submodelmanegerhousepet.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SubmodelManagerPet',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=50)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='SubmodelManegerHousePet',
+            fields=[
+                ('submodelmanagerpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.SubmodelManagerPet')),
+                ('trained', models.BooleanField(default=False)),
+                ('tags', taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', help_text='A comma-separated list of tags.', verbose_name='Tags')),
+            ],
+            options={
+            },
+            bases=('tests.submodelmanagerpet',),
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -153,7 +153,7 @@ class SubmodelManagerPet(models.Model):
     def __str__(self):
         return self.name
 
-class SubmodelManegerHousePet(SubmodelManagerPet):
+class SubmodelManagerHousePet(SubmodelManagerPet):
     trained = models.BooleanField(default=False)
 
     tags = TaggableManager()

--- a/tests/models.py
+++ b/tests/models.py
@@ -145,6 +145,19 @@ class OfficialPet(models.Model):
 class OfficialHousePet(OfficialPet):
     trained = models.BooleanField(default=False)
 
+# Test tag manager only defined on submodel
+
+class SubmodelManagerPet(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
+
+class SubmodelManegerHousePet(SubmodelManagerPet):
+    trained = models.BooleanField(default=False)
+
+    tags = TaggableManager()
+
 
 class Media(models.Model):
     tags = TaggableManager()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,7 +15,7 @@ from .models import (Article, Child, CustomManager, CustomPKFood,
                      DirectHousePet, DirectPet, Food, HousePet, Movie,
                      OfficialFood, OfficialHousePet, OfficialPet,
                      OfficialTag, OfficialThroughModel, Pet, Photo,
-                     SubmodelManegerHousePet, SubmodelManagerPet,
+                     SubmodelManagerHousePet, SubmodelManagerPet,
                      TaggedCustomPKFood, TaggedCustomPKPet, TaggedFood,
                      TaggedPet)
 
@@ -405,9 +405,9 @@ class TaggableManagerOfficialTestCase(TaggableManagerTestCase):
 
         self.assertEqual(apple, self.food_model.objects.get(tags__official=False))
 
-class TaggableManagerSubmodelManegerTestCase(BaseTaggingTestCase):
+class TaggableManagerSubmodelManagerTestCase(BaseTaggingTestCase):
     pet_model = SubmodelManagerPet
-    housepet_model = SubmodelManegerHousePet
+    housepet_model = SubmodelManagerHousePet
 
     def test_filter_join_on_tags(self):
         cat = self.housepet_model.objects.create(name="cat", trained=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,6 +15,7 @@ from .models import (Article, Child, CustomManager, CustomPKFood,
                      DirectHousePet, DirectPet, Food, HousePet, Movie,
                      OfficialFood, OfficialHousePet, OfficialPet,
                      OfficialTag, OfficialThroughModel, Pet, Photo,
+                     SubmodelManegerHousePet, SubmodelManagerPet,
                      TaggedCustomPKFood, TaggedCustomPKPet, TaggedFood,
                      TaggedPet)
 
@@ -368,6 +369,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 'apple': set(['1', '2'])
             })
 
+
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     food_model = DirectFood
     pet_model = DirectPet
@@ -402,6 +404,17 @@ class TaggableManagerOfficialTestCase(TaggableManagerTestCase):
         pear.tags.add("delicious")
 
         self.assertEqual(apple, self.food_model.objects.get(tags__official=False))
+
+class TaggableManagerSubmodelManegerTestCase(BaseTaggingTestCase):
+    pet_model = SubmodelManagerPet
+    housepet_model = SubmodelManegerHousePet
+
+    def test_filter_join_on_tags(self):
+        cat = self.housepet_model.objects.create(name="cat", trained=True)
+        cat.tags.add("fuzzy")
+        self.assertTrue(self.housepet_model.objects
+                        .filter(trained=True, tags__name="fuzzy")
+                        .exists())
 
 class TaggableManagerInitializationTestCase(TaggableManagerTestCase):
     """Make sure manager override defaults and sets correctly."""


### PR DESCRIPTION
In Django >= 1.6, taggable managers which are only defined on the submodel in a multi-table inheritance relationship incorrectly attempt to join on `id` instead of the submodel's primary key, which is its foreign key to the parent model. This is probably best explained by reading the test that I wrote in this branch, but to reproduce the bug, I essentially copied the Pet and HousePet relationship defined for the other tests and defined the TaggableManager only on HousePet. You can confirm that my test fails on Django 1.6 without the fix contained in this branch.

The reason this fails is that the `get_joining_columns()` method on TaggableManager hardcodes `id` and `object_id` for the generic foreign key to and from fields. This method is only used in Django 1.6 and 1.7, so Django 1.5 and 1.4 aren't affected. To fix this, I copied the definition of [`get_joining_columns()` from Django 1.6.7's ForeignObject](https://github.com/django/django/blob/1.6.7/django/db/models/fields/related.py#L1019-L1021), which is what TaggableManager seems to be modeled after, which dynamically determines which columns to use based on the related fields.

I tested this fix by running the tests, including my new tests, on Django 1.4.8, 1.5.4, 1.6.7, and 1.7.