### PR TITLE
Add transliteration support for slug

### DIFF
--- a/requirements/pip_requirements.txt
+++ b/requirements/pip_requirements.txt
@@ -1,0 +1,6 @@
+Django==1.7
+argparse==1.2.1
+lorem-ipsum-generator==0.3
+six==1.8.0
+transliterate==1.7.3
+wsgiref==0.1.2

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -5,8 +5,7 @@ from django.db import IntegrityError, models, transaction
 from django.db.models.query import QuerySet
 from django.template.defaultfilters import slugify as default_slugify
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext
+from transliterate import translit
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
@@ -76,6 +75,7 @@ class TagBase(models.Model):
             return super(TagBase, self).save(*args, **kwargs)
 
     def slugify(self, tag, i=None):
+        tag = translit(tag, reversed=True)
         slug = default_slugify(tag)
         if i is not None:
             slug += "_%d" % i

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, models, transaction
 from django.db.models.query import QuerySet
-from django.template.defaultfilters import slugify as default_slugify
 from django.utils.encoding import python_2_unicode_compatible
-from transliterate import translit
+from django.utils.translation import ugettext_lazy as _, ugettext
+from transliterate import slugify as trans_slugify
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
@@ -75,8 +75,8 @@ class TagBase(models.Model):
             return super(TagBase, self).save(*args, **kwargs)
 
     def slugify(self, tag, i=None):
-        tag = translit(tag, reversed=True)
-        slug = default_slugify(tag)
+        # May be need more tests for language detect and slugify to uk
+        slug = trans_slugify(tag, 'uk')
         if i is not None:
             slug += "_%d" % i
         return slug


### PR DESCRIPTION
Fix errors for non-english tags, when slug == empty str
Now: if Tag == u'Русский тег', after slugify => slug == u'russkyj-teh'