### PR TITLE
handle adding tags using through when table is case-insensitive

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -152,7 +152,14 @@ class _TaggableManager(models.Manager):
         tag_objs.update(existing)
 
         for new_tag in str_tags - set(t.name for t in existing):
-            tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
+            try:
+                tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
+            except Exception as e:
+                # We should pass here for case-insensitive tables
+                if len(e.args) > 1 and 'duplicate entry' in e.args[1].lower():
+                    pass
+                else:
+                    raise e
 
         for tag in tag_objs:
             self.through.objects.get_or_create(tag=tag, **self._lookup_kwargs())


### PR DESCRIPTION
I have the following:

```Python
class CampaignFeature(TaggedItemBase):
    content_object = models.ForeignKey('Campaign')
    order = models.IntegerField(blank=True, null=True)

    class Meta:
        ordering = ('order',)


class Campaign(models.Model):
    features = TaggableManager(
        verbose_name='Campaign features',
        blank=True,
        through=CampaignFeature)
```

When I create a ```Campaign``` object in admin, and use for example ```"Smartphone app"``` as one of the tags, then I create another using ```"Smartphone App"```, I get an IntegrityError ```(1062, "Duplicate entry '<sometag>' for key 'name'")```

As my MySQL table columns are case-insensitive, an interesting behaviour happens with taggit:

https://github.com/ivancrneto/django-taggit/blob/develop/taggit/managers.py#L154
```Python
        for new_tag in str_tags - set(t.name for t in existing):
            tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
```
The error is raised in this instruction. Right before this, we have:

```Python
str_tags == set([u'Smartphone App'])  # we are trying to add 'Smartphone App' in the second creation
# [...]
existing = self.through.tag_model().objects.filter(
            name__in=str_tags
        )
# query: SELECT `taggit_tag`.`id`, `taggit_tag`.`name`, `taggit_tag`.`slug` FROM `taggit_tag` WHERE `taggit_tag`.`name` IN ("Smartphone App");

existing == [<Tag: Smartphone app>]
```
The first tag we added is returned by the query because the table is case-insensitive.

```Python
set(t.name for t in existing) == set([u'Smartphone app'])
str_tags - set(t.name for t in existing) == set([u'Smartphone App'])
```
So it tries to add "Smartphone App" and the db raises ERROR 1062 (23000): Duplicate entry 'Smartphone App' for key 'name' because there is already a 'Smartphone app' in a case-insensitive column.

Checking for the exception and just passing if the IntegrityError is related with 'Duplicate entry' is enough because ```tag_objs``` already has the existing tag, as in the line 152 we have:
```Python
tag_objs.update(existing)
```