### PR TITLE
Prefetching tags leads to 1 extra join

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -87,11 +87,12 @@ class _TaggableManager(models.Manager):
     def is_cached(self, instance):
         return self.prefetch_cache_name in instance._prefetched_objects_cache
 
-    def get_queryset(self):
+    def get_queryset(self, extra_filters=None):
         try:
             return self.instance._prefetched_objects_cache[self.prefetch_cache_name]
         except (AttributeError, KeyError):
-            return self.through.tags_for(self.model, self.instance)
+            kwargs = extra_filters if extra_filters else {}
+            return self.through.tags_for(self.model, self.instance, **kwargs)
 
     def get_prefetch_queryset(self, instances, queryset=None):
         if queryset is not None:
@@ -112,7 +113,7 @@ class _TaggableManager(models.Manager):
         source_col = fk.column
         connection = connections[db]
         qn = connection.ops.quote_name
-        qs = self.get_queryset().using(db)._next_is_sticky().filter(**query).extra(
+        qs = self.get_queryset(query).using(db).extra(
             select={
                 '_prefetch_related_val': '%s.%s' % (qn(join_table), qn(source_col))
             }

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -127,14 +127,17 @@ class TaggedItemBase(ItemBase):
         abstract = True
 
     @classmethod
-    def tags_for(cls, model, instance=None):
+    def tags_for(cls, model, instance=None, **extra_filters):
+        kwargs = extra_filters or {}
         if instance is not None:
-            return cls.tag_model().objects.filter(**{
+            kwargs.update({
                 '%s__content_object' % cls.tag_relname(): instance
             })
-        return cls.tag_model().objects.filter(**{
+            return cls.tag_model().objects.filter(**kwargs)
+        kwargs.update({
             '%s__content_object__isnull' % cls.tag_relname(): False
-        }).distinct()
+        })
+        return cls.tag_model().objects.filter(**kwargs).distinct()
 
 
 class GenericTaggedItemBase(ItemBase):
@@ -172,13 +175,15 @@ class GenericTaggedItemBase(ItemBase):
             }
 
     @classmethod
-    def tags_for(cls, model, instance=None):
+    def tags_for(cls, model, instance=None, **extra_filters):
         ct = ContentType.objects.get_for_model(model)
         kwargs = {
             "%s__content_type" % cls.tag_relname(): ct
         }
         if instance is not None:
             kwargs["%s__object_id" % cls.tag_relname()] = instance.pk
+        if extra_filters:
+            kwargs.update(extra_filters)
         return cls.tag_model().objects.filter(**kwargs).distinct()
 
 


### PR DESCRIPTION
Before (2 joins):

```
SELECT DISTINCT ("taggit_taggeditem"."object_id") AS "_prefetch_related_val", "taggit_tag"."id", "taggit_tag"."name", "taggit_tag"."slug" 
FROM "taggit_tag" INNER JOIN "taggit_taggeditem" ON ( "taggit_tag"."id" = "taggit_taggeditem"."tag_id" )
INNER JOIN "taggit_taggeditem" T4 ON ( "taggit_tag"."id" = T4."tag_id" ) 
WHERE ("taggit_taggeditem"."content_type_id" = %s AND T4."object_id" IN (%s))
```

After (1 join):

```
SELECT DISTINCT ("taggit_taggeditem"."object_id") AS "_prefetch_related_val", "taggit_tag"."id", "taggit_tag"."name", "taggit_tag"."slug" 
FROM "taggit_tag" INNER JOIN "taggit_taggeditem" ON ( "taggit_tag"."id" = "taggit_taggeditem"."tag_id" )
WHERE ("taggit_taggeditem"."content_type_id" = %s AND "taggit_taggeditem"."object_id" IN (%s))
```

Avoid using ORM private api (sticky_filter) and use one filter call instead of 2 to reduce number of joins.

Above query (1) was kinda slow with large number of tagged items on our setup (postgres).