### PR TITLE
Add get_internal_type to TaggableManager for #285

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -298,6 +298,9 @@ class TaggableManager(RelatedField, Field):
             else:
                 self.post_through_setup(cls)
 
+    def get_internal_type(self):
+        return 'ManyToManyField'
+
     def __lt__(self, other):
         """
         Required contribute_to_class as Django uses bisect

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -368,6 +368,11 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 'apple': set(['1', '2'])
             })
 
+    def test_internal_type_is_manytomany(self):
+        self.assertEqual(
+            TaggableManager().get_internal_type(), 'ManyToManyField'
+        )
+
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     food_model = DirectFood
     pet_model = DirectPet


### PR DESCRIPTION
Adds a `get_internal_type` method to `TaggableManager` to complement @coldmind's fix for #285 in django/django#3865