### PR TITLE
Identify as a ManyToManyField (fixing Django 1.7 migrations)

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -253,6 +253,9 @@ class TaggableManager(RelatedField, Field):
         )
         return manager
 
+    def get_internal_type(self):
+        return 'ManyToManyField'
+
     def deconstruct(self):
         """
         Deconstruct the object, used with migrations.


### PR DESCRIPTION
Comply with Django's 1.7 fix for working with ManyToManyField spin-offs: https://github.com/django/django/commit/3d4a826174b7a411a03be39725e60c940944a7fe