### PR TITLE
Django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ env:
   - TOXENV=py27-1.5.x
   - TOXENV=py27-1.6.x
   - TOXENV=py27-1.7.x
+  - TOXENV=py27-1.8.x
   - TOXENV=py33-1.5.x
   - TOXENV=py33-1.6.x
   - TOXENV=py33-1.7.x
+  - TOXENV=py33-1.8.x
   - TOXENV=py34-1.5.x
   - TOXENV=py34-1.6.x
   - TOXENV=py34-1.7.x
+  - TOXENV=py34-1.8.x
 install:
   - pip install flake8 tox
 before_script:

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -231,6 +231,12 @@ class _TaggableManager(models.Manager):
 
 
 class TaggableManager(RelatedField, Field):
+    # Field flags
+    many_to_many = True
+    many_to_one = False
+    one_to_many = False
+    one_to_one = False
+
     _related_name_counter = 0
 
     def __init__(self, verbose_name=_("Tags"),

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -243,12 +243,22 @@ class TaggableManager(RelatedField, Field):
                  help_text=_("A comma-separated list of tags."),
                  through=None, blank=False, related_name=None, to=None,
                  manager=_TaggableManager):
-        Field.__init__(self, verbose_name=verbose_name, help_text=help_text,
-                       blank=blank, null=True, serialize=False)
+
         self.through = through or TaggedItem
-        self.rel = TaggableRel(self, related_name, self.through, to=to)
         self.swappable = False
         self.manager = manager
+
+        rel = TaggableRel(self, related_name, self.through, to=to)
+
+        Field.__init__(
+            self,
+            verbose_name=verbose_name,
+            help_text=help_text,
+            blank=blank,
+            null=True,
+            serialize=False,
+            rel=rel,
+        )
         # NOTE: `to` is ignored, only used via `deconstruct`.
 
     def __get__(self, instance, model):

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -232,6 +232,12 @@ class _TaggableManager(models.Manager):
             results.append(obj)
         return results
 
+    # _TaggableManager needs to be hashable but BaseManagers in Django 1.8+ overrides
+    # the __eq__ method which makes the default __hash__ method disappear.
+    # This checks if the __hash__ attribute is None, and if so, it reinstates the original method.
+    if models.Manager.__hash__ is None:
+        __hash__ = object.__hash__
+
 
 class TaggableManager(RelatedField, Field):
     # Field flags

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -28,9 +28,12 @@ except ImportError:  # django < 1.7
     from django.contrib.contenttypes.generic import GenericRelation
 
 try:
-    from django.db.models.related import PathInfo
-except ImportError:
-    pass  # PathInfo is not used on Django < 1.6
+    from django.db.models.query_utils import PathInfo
+except ImportError:  # Django < 1.8
+    try:
+        from django.db.models.related import PathInfo
+    except ImportError:
+        pass  # PathInfo is not used on Django < 1.6
 
 
 def _model_name(model):

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -9,9 +9,15 @@ from django.db.models.fields import Field
 from django.db.models.fields.related import (add_lazy_relation, ManyToManyRel,
                                              OneToOneRel, RelatedField)
 
-try:
+if VERSION < (1, 8):
+    # related.py was removed in Django 1.8
+
+    # Depending on how Django was updated, related.py could still exist
+    # on the users system even on Django 1.8+, so we check the Django
+    # version before importing it to make sure this doesn't get imported
+    # accidentally.
     from django.db.models.related import RelatedObject
-except ImportError:  # Django 1.8 +
+else:
     RelatedObject = None
 
 from django.utils import six

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models, router
 from django.db.models.fields import Field
 from django.db.models.fields.related import (add_lazy_relation, ManyToManyRel,
-                                             RelatedField)
+                                             OneToOneRel, RelatedField)
 
 try:
     from django.db.models.related import RelatedObject
@@ -512,6 +512,13 @@ def _get_subclasses(model):
     subclasses = [model]
     for f in model._meta.get_all_field_names():
         field = model._meta.get_field_by_name(f)[0]
+
+        # Django 1.8 +
+        if (not RelatedObject and isinstance(field, OneToOneRel) and
+                getattr(field.field.rel, "parent_link", None)):
+            subclasses.extend(_get_subclasses(field.related_model))
+
+        # < Django 1.8
         if (RelatedObject and isinstance(field, RelatedObject) and
                 getattr(field.field.rel, "parent_link", None)):
             subclasses.extend(_get_subclasses(field.model))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -336,7 +336,14 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         self.assertTrue(hasattr(field, 'rel'))
         self.assertTrue(hasattr(field.rel, 'to'))
         self.assertTrue(hasattr(field, 'related'))
-        self.assertEqual(self.food_model, field.related.model)
+
+        # This API has changed in Django 1.8
+        # https://code.djangoproject.com/ticket/21414
+        if django.VERSION >= (1, 8):
+            self.assertEqual(self.food_model, field.model)
+            self.assertEqual(self.tag_model, field.related.model)
+        else:
+            self.assertEqual(self.food_model, field.related.model)
 
     def test_names_method(self):
         apple = self.food_model.objects.create(name="apple")

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps16 =
 	https://github.com/django/django/archive/stable/1.6.x.zip#egg=django
 deps17 =
 	https://github.com/django/django/archive/stable/1.7.x.zip#egg=django
+deps18 =
+	https://github.com/django/django/archive/stable/1.8.x.zip#egg=django
 
 commands =
 	python ./runtests.py {posargs}
@@ -58,6 +60,12 @@ deps =
 	{[testenv]deps}
 	{[testenv]deps17}
 
+[testenv:py27-1.8.x]
+basepython = python2.7
+deps =
+	{[testenv]deps}
+	{[testenv]deps18}
+
 [testenv:py33-1.5.x]
 basepython = python3.3
 deps =
@@ -76,6 +84,12 @@ deps =
 	{[testenv]deps}
 	{[testenv]deps17}
 
+[testenv:py33-1.8.x]
+basepython = python3.3
+deps =
+	{[testenv]deps}
+	{[testenv]deps18}
+
 [testenv:py34-1.5.x]
 basepython = python3.4
 deps =
@@ -93,3 +107,9 @@ basepython = python3.4
 deps =
 	{[testenv]deps}
 	{[testenv]deps17}
+
+[testenv:py34-1.8.x]
+basepython = python3.4
+deps =
+	{[testenv]deps}
+	{[testenv]deps18}

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,15 @@ usedevelop = True
 deps =
 	flake8
 deps14 =
-	https://github.com/django/django/archive/stable/1.4.x.zip#egg=django
+	https://github.com/django/django/archive/stable/1.4.x.tar.gz#egg=django
 deps15 =
-	https://github.com/django/django/archive/stable/1.5.x.zip#egg=django
+	https://github.com/django/django/archive/stable/1.5.x.tar.gz#egg=django
 deps16 =
-	https://github.com/django/django/archive/stable/1.6.x.zip#egg=django
+	https://github.com/django/django/archive/stable/1.6.x.tar.gz#egg=django
 deps17 =
-	https://github.com/django/django/archive/stable/1.7.x.zip#egg=django
+	https://github.com/django/django/archive/stable/1.7.x.tar.gz#egg=django
 deps18 =
-	https://github.com/django/django/archive/stable/1.8.x.zip#egg=django
+	https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
 
 commands =
 	python ./runtests.py {posargs}


### PR DESCRIPTION
Addresses #284 

This brings Taggit up to speed with Django 1.8 beta 2. There may be more work to do before the final release but this should get us most of the way there.