### PR TITLE
Fixes #101 and #189

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -124,13 +124,15 @@ class ItemBase(models.Model):
     @classmethod
     def tags_for(cls, model, instance=None, **extra_filters):
         kwargs = extra_filters or {}
+        relname = cls.tag_relname() or cls.__name__.lower()
+
         if instance is not None:
             kwargs.update({
-                '%s__content_object' % cls.tag_relname(): instance
+                '%s__content_object' % relname: instance
             })
             return cls.tag_model().objects.filter(**kwargs)
         kwargs.update({
-            '%s__content_object__isnull' % cls.tag_relname(): False
+            '%s__content_object__isnull' % relname: False
         })
         return cls.tag_model().objects.filter(**kwargs).distinct()
 

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -121,13 +121,6 @@ class ItemBase(models.Model):
             "content_object__in": instances,
         }
 
-
-class TaggedItemBase(ItemBase):
-    tag = models.ForeignKey(Tag, related_name="%(app_label)s_%(class)s_items")
-
-    class Meta:
-        abstract = True
-
     @classmethod
     def tags_for(cls, model, instance=None, **extra_filters):
         kwargs = extra_filters or {}
@@ -140,6 +133,13 @@ class TaggedItemBase(ItemBase):
             '%s__content_object__isnull' % cls.tag_relname(): False
         })
         return cls.tag_model().objects.filter(**kwargs).distinct()
+
+
+class TaggedItemBase(ItemBase):
+    tag = models.ForeignKey(Tag, related_name="%(app_label)s_%(class)s_items")
+
+    class Meta:
+        abstract = True
 
 
 class GenericTaggedItemBase(ItemBase):

--- a/tests/migrations/0002_auto_20150602_1730.py
+++ b/tests/migrations/0002_auto_20150602_1730.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CustomFKFood',
+            fields=[
+                ('name', models.CharField(max_length=50, serialize=False, primary_key=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TaggedCustomFKFood',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_object', models.ForeignKey(to='tests.CustomFKFood')),
+                ('tag', models.ForeignKey(related_name='custom_fk_food', to='taggit.Tag')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='customfkfood',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomFKFood', help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/tests/migrations/0003_auto_20150602_1731.py
+++ b/tests/migrations/0003_auto_20150602_1731.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('tests', '0002_auto_20150602_1730'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CustomFKFoodNoRelatedName',
+            fields=[
+                ('name', models.CharField(max_length=50, serialize=False, primary_key=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TaggedCustomFKFoodNoRelatedName',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_object', models.ForeignKey(to='tests.CustomFKFoodNoRelatedName')),
+                ('tag', models.ForeignKey(to='taggit.Tag')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='customfkfoodnorelatedname',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomFKFoodNoRelatedName', help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,8 +4,8 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
 from taggit.managers import TaggableManager
-from taggit.models import (GenericTaggedItemBase, Tag, TagBase, TaggedItem,
-                           TaggedItemBase)
+from taggit.models import (ItemBase, GenericTaggedItemBase, Tag, TagBase,
+                           TaggedItem, TaggedItemBase)
 
 
 # Ensure that two TaggableManagers with custom through model are allowed.
@@ -115,6 +115,21 @@ class CustomPKPet(models.Model):
 
 class CustomPKHousePet(CustomPKPet):
     trained = models.BooleanField(default=False)
+
+# Test custom through model to model with custom FK
+class TaggedCustomFKFood(ItemBase):
+    tag = models.ForeignKey(Tag, related_name='custom_fk_food')
+
+    content_object = models.ForeignKey('CustomFKFood')
+
+@python_2_unicode_compatible
+class CustomFKFood(models.Model):
+    name = models.CharField(max_length=50, primary_key=True)
+
+    tags = TaggableManager(through=TaggedCustomFKFood)
+
+    def __str__(self):
+        return self.name
 
 # Test custom through model to a custom tag model
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -122,11 +122,26 @@ class TaggedCustomFKFood(ItemBase):
 
     content_object = models.ForeignKey('CustomFKFood')
 
+# Test custom through model to model with custom FK
+class TaggedCustomFKFoodNoRelatedName(ItemBase):
+    tag = models.ForeignKey(Tag)
+
+    content_object = models.ForeignKey('CustomFKFoodNoRelatedName')
+
 @python_2_unicode_compatible
 class CustomFKFood(models.Model):
     name = models.CharField(max_length=50, primary_key=True)
 
     tags = TaggableManager(through=TaggedCustomFKFood)
+
+    def __str__(self):
+        return self.name
+
+@python_2_unicode_compatible
+class CustomFKFoodNoRelatedName(models.Model):
+    name = models.CharField(max_length=50, primary_key=True)
+
+    tags = TaggableManager(through=TaggedCustomFKFoodNoRelatedName)
 
     def __str__(self):
         return self.name

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,11 +11,11 @@ from django.test import TestCase, TransactionTestCase
 from django.utils.encoding import force_text
 
 from .forms import CustomPKFoodForm, DirectFoodForm, FoodForm, OfficialFoodForm
-from .models import (Article, Child, CustomManager, CustomFKFood, CustomPKFood,
-                     CustomPKHousePet, CustomPKPet, DirectFood,
-                     DirectHousePet, DirectPet, Food, HousePet, Movie,
-                     OfficialFood, OfficialHousePet, OfficialPet,
-                     OfficialTag, OfficialThroughModel, Pet, Photo,
+from .models import (Article, Child, CustomManager, CustomFKFood,
+                     CustomFKFoodNoRelatedName, CustomPKFood, CustomPKHousePet,
+                     CustomPKPet, DirectFood, DirectHousePet, DirectPet, Food,
+                     HousePet, Movie, OfficialFood, OfficialHousePet,
+                     OfficialPet, OfficialTag, OfficialThroughModel, Pet, Photo,
                      TaggedCustomPKFood, TaggedCustomPKPet, TaggedFood,
                      TaggedPet)
 
@@ -115,6 +115,10 @@ class TagModelCustomPKTestCase(TagModelTestCase):
 
 class TagModelCustomFKTestCase(TagModelTestCase):
     food_model = CustomFKFood
+    tag_model = Tag
+
+class TagModelCustomFKNoRelatedNameTestCase(TagModelTestCase):
+    food_model = CustomFKFoodNoRelatedName
     tag_model = Tag
 
 class TagModelOfficialTestCase(TagModelTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,7 +11,7 @@ from django.test import TestCase, TransactionTestCase
 from django.utils.encoding import force_text
 
 from .forms import CustomPKFoodForm, DirectFoodForm, FoodForm, OfficialFoodForm
-from .models import (Article, Child, CustomManager, CustomPKFood,
+from .models import (Article, Child, CustomManager, CustomFKFood, CustomPKFood,
                      CustomPKHousePet, CustomPKPet, DirectFood,
                      DirectHousePet, DirectPet, Food, HousePet, Movie,
                      OfficialFood, OfficialHousePet, OfficialPet,
@@ -111,6 +111,10 @@ class TagModelDirectTestCase(TagModelTestCase):
 
 class TagModelCustomPKTestCase(TagModelTestCase):
     food_model = CustomPKFood
+    tag_model = Tag
+
+class TagModelCustomFKTestCase(TagModelTestCase):
+    food_model = CustomFKFood
     tag_model = Tag
 
 class TagModelOfficialTestCase(TagModelTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -97,6 +97,14 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
                 r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
             apple.tags.add(1)
 
+    def test_tags_for_model(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("Red", "red")
+
+        self.assert_tags_equal(apple.tags.through.tags_for(self.food_model,
+                                                           apple),
+                               ['Red', 'red'])
+
 class TagModelDirectTestCase(TagModelTestCase):
     food_model = DirectFood
     tag_model = Tag


### PR DESCRIPTION
Custom `ItemBase` subclasses should always reimplement the `tags_for()` method, so it has been moved from `TaggedItemBase` to `ItemBase`. `GenericTaggedItemBase` reimplements it, so there should be no harm.

`tag_relname()` returns `None` if the intermediary model does not define `related_name` for the `ForeignKey` to the tag model, which is breaking the lookup in `tags_for()`. This is fixed by falling back to the lowercased model name.

I'm not sure how to handle the migration files for the tests model, so I'm simply adding two new migrations for now.