### PR TITLE
Add 'django-taggit-helpers' to external apps list in docs

### DIFF
--- a/docs/external_apps.txt
+++ b/docs/external_apps.txt
@@ -20,7 +20,12 @@ If you have an application that you'd like to see listed here, simply fork
  * ``django-taggit-templatetags``: Provides several templatetags, including one
    for tag clouds, to expose various ``taggit`` APIs directly to templates.
    Available on `github`__.
+ * ``django-taggit-helpers``: Makes it easier to work with admin pages of models
+   associated with ``taggit`` tags by adding helper classes: ``TaggitCounter``,
+   ``TaggitListFilter``, ``TaggitStackedInline``, ``TaggitTabularInline``.
+   Available on `github`__.
 
 __ http://github.com/alex/django-taggit
 __ http://github.com/frankwiles/django-taggit-suggest
 __ http://github.com/feuervogel/django-taggit-templatetags
+__ http://github.com/mfcovington/django-taggit-helpers


### PR DESCRIPTION
``django-taggit-helpers`` ([GitHub](https://github.com/mfcovington/django-taggit-helpers)/[PyPI](https://pypi.python.org/pypi/django-taggit-helpers)) makes it easier to work with admin pages of models associated with ``django-taggit`` tags by adding some helper classes:

  - ``TaggitCounter``: Display (and sort by) number of Taggit tags associated with tagged items.
  - ``TaggitListFilter``: Filter records by Taggit tags for the current model only. 
  - ``TaggitStackedInline``: Add stacked inline for Taggit tags to admin.
  - ``TaggitTabularInline``: Add tabular inline for Taggit tags to admin.