### PR TITLE
Unicode tags do not have correct slugs (redux)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,6 @@ import taggit
 with open('README.rst') as f:
     readme = f.read()
 
-install_requires = (
-    "Unidecode>=0.04.14",
-)
-
 setup(
     name='django-taggit',
     version='.'.join(str(i) for i in taggit.VERSION),

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@ import taggit
 with open('README.rst') as f:
     readme = f.read()
 
+install_requires = (
+    "Unidecode>=0.04.14",
+)
+
 setup(
     name='django-taggit',
     version='.'.join(str(i) for i in taggit.VERSION),

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 
 from taggit.utils import _get_field
+from unidecode import unidecode
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
@@ -78,7 +79,7 @@ class TagBase(models.Model):
             return super(TagBase, self).save(*args, **kwargs)
 
     def slugify(self, tag, i=None):
-        slug = default_slugify(tag)
+        slug = default_slugify(unidecode(tag))
         if i is not None:
             slug += "_%d" % i
         return slug

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -9,7 +9,11 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 
 from taggit.utils import _get_field
-from unidecode import unidecode
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = lambda tag: tag
+
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey


### PR DESCRIPTION
Fix for non latin characters in slugs being removed and empty slugs being created. This is a resubmission of @spapas PR (see https://github.com/alex/django-taggit/issues/272) slightly modified to not have a dependency on a GPL licensed library and rebased so it applies on the current HEAD.