### PR TITLE
Adds django-taggit-labels to external apps list

### DIFF
--- a/docs/external_apps.txt
+++ b/docs/external_apps.txt
@@ -24,8 +24,11 @@ If you have an application that you'd like to see listed here, simply fork
    associated with ``taggit`` tags by adding helper classes: ``TaggitCounter``,
    ``TaggitListFilter``, ``TaggitStackedInline``, ``TaggitTabularInline``.
    Available on `github`__.
+ * ``django-taggit-labels``: Provides a clickable label widget for the
+   Django admin for user friendly selection from managed tag sets.
 
 __ http://github.com/alex/django-taggit
 __ http://github.com/frankwiles/django-taggit-suggest
 __ http://github.com/feuervogel/django-taggit-templatetags
 __ http://github.com/mfcovington/django-taggit-helpers
+__ https://github.com/bennylope/django-taggit-labels


### PR DESCRIPTION
The label widget does not expose the input field so that you can add new tags. The base label widget instead shows all available tags and lets you pick between them in Django's admin interface. It presumes that you are using a managed tag list.