### PR TITLE
Patch django-taggit to fix #282

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -494,7 +494,7 @@ class TaggableManager(RelatedField, Field):
         if reverse_join:
             return ((self.model._meta.pk.column, "object_id"),)
         else:
-            return ((self.model._meta.pk.column, "id"),)
+            return (("object_id", self.model._meta.pk.column),)
 
     def get_extra_restriction(self, where_class, alias, related_alias):
         extra_col = _get_field(self.through, 'content_type').column

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -492,9 +492,9 @@ class TaggableManager(RelatedField, Field):
 
     def get_joining_columns(self, reverse_join=False):
         if reverse_join:
-            return (("id", "object_id"),)
+            return ((self.model._meta.pk.column, "object_id"),)
         else:
-            return (("object_id", "id"),)
+            return ((self.model._meta.pk.column, "id"),)
 
     def get_extra_restriction(self, where_class, alias, related_alias):
         extra_col = _get_field(self.through, 'content_type').column


### PR DESCRIPTION
django-taggit has a bug (#282) where it assumes that the tagged model
has a field named id which is the primary key. This isn't the case in
our database as we use a more descriptive pk/id field name. The django-taggit API lookup features fail unless this is fixed.

This commit patches the code using the fix in:
#283 and stevenday/django-taggit