### PR TITLE
Add case-insensitive option for tag names.

### DIFF
--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -30,3 +30,10 @@ And then to any model you want tagging on do the following::
         # ... fields here
 
         tags = TaggableManager()
+
+.. note::
+
+    If you want ``django-taggit`` to be **CASE INSENSITIVE** when looking up existing tags, you'll have to set to ``True`` the TAGGIT_CASE_INSENSITIVE setting (by default ``False``)::
+
+      TAGGIT_CASE_INSENSITIVE = True
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,6 +8,7 @@ from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import connection
 from django.test import TestCase, TransactionTestCase
+from django.test.utils import override_settings
 from django.utils.encoding import force_text
 
 from .forms import CustomPKFoodForm, DirectFoodForm, FoodForm, OfficialFoodForm
@@ -388,6 +389,13 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             l = list(self.food_model.objects.prefetch_related('tags').all())
             join_clause = 'INNER JOIN "%s"' % self.taggeditem_model._meta.db_table
             self.assertEqual(connection.queries[-1]['sql'].count(join_clause), 1, connection.queries[-2:])
+
+    @override_settings(TAGGIT_CASE_INSENSITIVE=True)
+    def test_with_case_insensitive_option(self):
+        spain = self.tag_model.objects.create(name="Spain", slug="spain")
+        orange = self.food_model.objects.create(name="orange")
+        orange.tags.add('spain')
+        self.assertEqual(list(orange.tags.all()), [spain])
 
 
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):


### PR DESCRIPTION
This commit was adapted from an unmerged pull request [#263](https://github.com/alex/django-taggit/pull/263) done by [qris](https://github.com/qrisa). The following text is his original commit message:

Add case-insensitive option for tag names.

I don't think it makes sense to have tags which differ only in case. It's not even possible on MySQL because it violates the
unique constraint on tag name:

    IntegrityError: (1062, "Duplicate entry 'LONDON' for key 'taggit_tag_name_6b48d50f_uniq'")

This PR adds a new setting, `TAGGIT_CASE_INSENSITIVE`, which causes existing tags to be looked up case insensitively. New
tags are added with the supplied case, which will be used from then on. The default behaviour is the same as before without
this setting.

This meets nookiepl's request on #70, and my comment on #9.