### PR TITLE
Use international ISO 8601 dates in the changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,49 +1,49 @@
 Changelog
 =========
 
-0.16.1 (07.09.2015)
+0.16.1 (2015-07-09)
 ~~~~~~~~~~~~~~~~~~~
  * Fix bug that assumed all primary keys are named 'id'
   * https://github.com/alex/django-taggit/pull/322
 
-0.16.0 (07.04.2015)
+0.16.0 (2015-07-04)
 ~~~~~~~~~~~~~~~~~~~
  * Add option to allow case-insensitive tags
   * https://github.com/alex/django-taggit/pull/325
 
-0.15.0 (06.23.2015)
+0.15.0 (2015-06-23)
 ~~~~~~~~~~~~~~~~~~~
  * Fix wrong slugs for non-latin chars
   * Only works if optional GPL dependency (unidecode) is installed
   * https://github.com/alex/django-taggit/pull/315
   * https://github.com/alex/django-taggit/pull/273
 
-0.14.0 (04.26.2015)
+0.14.0 (2015-04-26)
 ~~~~~~~~~~~~~~~~~~~
  * Prevent extra JOIN when prefetching
   * https://github.com/alex/django-taggit/pull/275
  * Prevent _meta warnings with Django 1.8
   * https://github.com/alex/django-taggit/pull/299
 
-0.13.0 (04.02.2015)
+0.13.0 (2015-04-02)
 ~~~~~~~~~~~~~~~~~~~
  * Django 1.8 support
   * https://github.com/alex/django-taggit/pull/297
 
-0.12.3 (03.03.2015)
+0.12.3 (2015-03-03)
 ~~~~~~~~~~~~~~~~~~~
  * Specify that the internal type of the TaggitManager is a ManyToManyField
 
-0.12.2 (21.09.2014)
+0.12.2 (2014-21-09)
 ~~~~~~~~~~~~~~~~~~~
  * Fixed 1.7 migrations.
 
-0.12.1 (10.08.2014)
+0.12.1 (2014-10-08)
 ~~~~~~~~~~~~~~~~~~~
  * Final (hopefully) fixes for the upcoming Django 1.7 release.
  * Added Japanese translation.
 
-0.12.0 (20.04.2014)
+0.12.0 (2014-20-04)
 ~~~~~~~~~~~~~~~~~~~
  * **Backwards incompatible:** Support for Django 1.7 migrations. South users
    have to set ``SOUTH_MIGRATION_MODULES`` to use ``taggit.south_migrations``
@@ -56,15 +56,15 @@ Changelog
    raised by the database, your app will have to handle that.
  * Added Italian and Esperanto translations.
 
-0.11.2 (13.12.2013)
+0.11.2 (2013-13-12)
 ~~~~~~~~~~~~~~~~~~~
  * Forbid multiple TaggableManagers via generic foreign keys.
 
-0.11.1 (25.11.2013)
+0.11.1 (2013-25-11)
 ~~~~~~~~~~~~~~~~~~~
  * Fixed support for Django 1.4 and 1.5.
 
-0.11.0 (25.11.2013)
+0.11.0 (2013-25-11)
 ~~~~~~~~~~~~~~~~~~~
  * Added support for prefetch_related on tags fields.
  * Fixed support for Django 1.7.
@@ -72,7 +72,7 @@ Changelog
  * Allow more than one TaggableManager on models (assuming concrete FKs are
    used for the relations).
 
-0.10.0 (17.08.2013)
+0.10.0 (2013-17-08)
 ~~~~~~~~~~~~~~~~~~~
 
  * Support for Django 1.6 and 1.7.
@@ -80,16 +80,16 @@ Changelog
  * **Backwards incompatible:** Dropped support for Django < 1.4.5.
  * Tag names are unique now, use the provided South migrations to upgrade.
 
-0.9.2
-~~~~~
+0.9.2 (2011-01-17)
+~~~~~~~~~~~~~~~~~~
 
  * **Backwards incompatible:**  Forms containing a :class:`TaggableManager` by
    default now require tags, to change this provide ``blank=True`` to the
    :class:`TaggableManager`.
  * Now works with Django 1.3 (as of beta-1).
 
-0.9.0
-~~~~~
+0.9.0 (2010-09-22)
+~~~~~~~~~~~~~~~~~~
 
  * Added a Hebrew locale.
  * Added an index on the ``object_id`` field of ``TaggedItem``.
@@ -104,8 +104,8 @@ Changelog
  * Removed ``taggit.contrib.suggest``, it now lives in an external application,
    see :doc:`external_apps` for more information.
 
-0.8.0
-~~~~~
+0.8.0 (2010-06-22)
+~~~~~~~~~~~~~~~~~~
 
  * Fixed querying for objects using ``exclude(tags__in=tags)``.
  * Marked strings as translatable.


### PR DESCRIPTION
Also, I've added dates for versions >= 0.9.2 (taken from git tags).