### PR TITLE
Add Meta app_label to models to fix RemovedInDjango19Warning

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -93,6 +93,7 @@ class Tag(TagBase):
     class Meta:
         verbose_name = _("Tag")
         verbose_name_plural = _("Tags")
+        app_label = 'taggit'
 
 
 @python_2_unicode_compatible
@@ -198,3 +199,4 @@ class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
     class Meta:
         verbose_name = _("Tagged Item")
         verbose_name_plural = _("Tagged Items")
+        app_label = 'taggit'


### PR DESCRIPTION
Added app_label to taggit.models.TaggedItem and taggit.models.Tag because of RemovedInDjango19Warnings in Django 1.8 

> RemovedInDjango19Warning: Model class taggit.models.Tag doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.