### PR TITLE
Added ability to configure tag state

### DIFF
--- a/taggit/migrations/0003_tag_state.py
+++ b/taggit/migrations/0003_tag_state.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0001_initial'),
+        ('taggit', '0002_auto_20150616_2121'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='tag',
+            name='state',
+            field=models.PositiveSmallIntegerField(default=0, choices=[(0, 'Published'), (1, 'Hidden')]),
+        ),
+    ]

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import django
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, models, transaction
 from django.db.models.query import QuerySet
@@ -37,6 +38,22 @@ except AttributeError:
             raise
         else:
             transaction.savepoint_commit(sid, using=using)
+
+# Default tag states
+default_states = (
+    (0, _('Published')), (1, _('Hidden')),
+)
+
+
+def get_states():
+    """
+    Defining of tag states
+    """
+    if hasattr(settings, 'TAG_STATES'):
+        states = settings.TAG_STATES
+    else:
+        states = default_states
+    return states
 
 
 @python_2_unicode_compatible
@@ -94,6 +111,8 @@ class TagBase(models.Model):
 
 
 class Tag(TagBase):
+    state = models.PositiveSmallIntegerField(default=0, choices=get_states(), )
+
     class Meta:
         verbose_name = _("Tag")
         verbose_name_plural = _("Tags")


### PR DESCRIPTION
I propose to add state field to tag. It seems to me very uncomfortable to create extra table for ability to configure tag state. Moreover, in that case, the query map is getting worse.

Also we can use custom setting of states by adding tuple TAG_STATES to Django settings.