### PR TITLE
Django 1.9 support for TaggableRel

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,7 +20,13 @@ from .models import (Article, Child, CustomManager, CustomPKFood,
                      TaggedCustomPKFood, TaggedCustomPKPet, TaggedFood,
                      TaggedPet)
 
-from taggit.managers import _model_name, _TaggableManager, TaggableManager
+from taggit.managers import (
+    _model_name,
+    _TaggableManager,
+    TaggableManager,
+    taggablerel_model_attr
+)
+
 from taggit.models import Tag, TaggedItem
 
 from taggit.utils import edit_string_for_tags, parse_tags
@@ -336,7 +342,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         # Check if tag field, which simulates m2m, has django-like api.
         field = self.food_model._meta.get_field('tags')
         self.assertTrue(hasattr(field, 'rel'))
-        self.assertTrue(hasattr(field.rel, 'to'))
+        self.assertTrue(hasattr(field.rel, taggablerel_model_attr))
         self.assertTrue(hasattr(field, 'related'))
 
         # This API has changed in Django 1.8


### PR DESCRIPTION
In the new alpha 1a release of Django 1.9 `TaggableRel.to` is replaced by `TaggableRel.model` (on the underlying `ForeignObjectRel` superclass.

This PR address that in a way that I think is compatible with < 1.9 (`to` as an attribute), 1.9 (`to` as a property) and > 1.9 (`to` removed). It's an example, you may want to implement it in a different way, so I'm not expecting it to be accepted necessarily.

The existing tests related to it pass. (Other tests fail with 1.9 alpha, but I've got a separate PR for that.)