### PR TITLE
Django 1.9 support for undocumented addition of contains_aggregate

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -72,6 +72,8 @@ class ExtraJoinRestriction(object):
     """
     An extra restriction used for contenttype restriction in joins.
     """
+    contains_aggregate = False
+
     def __init__(self, alias, col, content_types):
         self.alias = alias
         self.col = col


### PR DESCRIPTION
In Django commit [afe0bb7](https://github.com/django/django/commit/afe0bb7b13bb8dc4370f32225238012c873b0ee3#diff-73bc0dcb1a1c931adcf1d344abca22ff) and check for a `contains_aggregate` is made which assumes that attribute is present.

This causes an exception when `ExtraJoinRestriction` is checked:

```
File ".../django/db/models/sql/where.py", line 157, in _contains_aggregate
    return obj.contains_aggregate
AttributeError: 'ExtraJoinRestriction' object has no attribute 'contains_aggregate'
```

This causes three errors in the taggit tests.

This PR sets the attribute to False in ``ExtraJoinRestriction`` which, other than preventing the error, I think is benign for Django < 1.9 and >= 1.9.
 