### PR TITLE
Added a call to super init in _TaggableManager

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -100,6 +100,7 @@ class ExtraJoinRestriction(object):
 
 class _TaggableManager(models.Manager):
     def __init__(self, through, model, instance, prefetch_cache_name):
+        super(_TaggableManager, self).__init__()
         self.through = through
         self.model = model
         self.instance = instance


### PR DESCRIPTION
This fixes an issue I ran into with `django-taggit` and Django 1.8 -- the Django admin list view for one of my models failed to render, with this error:

```python
AttributeError: '_TaggableManager' object has no attribute 'name'
```

This error resulted from a call to `_TaggableManager.__str__()`, which now requires that the manager have a `name` attribute.  `BaseManager.__init__()` sets the `name` attribute, so I thought it appropriate to let that happen here.