### PR TITLE
Allows custom Through Model with GenericForeignKey

### DIFF
--- a/docs/custom_tagging.txt
+++ b/docs/custom_tagging.txt
@@ -10,6 +10,22 @@ want to store additional data about a tag, such as whether it is official.  In
 these cases ``django-taggit`` makes it easy to substitute your own through
 model, or ``Tag`` model.
 
+To change the behavior there are a number of classes you can subclass to obtain
+different behavior:
+
+=============================== =======================================================================
+Class name                      Behavior
+=============================== =======================================================================
+``TaggedItemBase``              Allows custom ``ForeignKeys`` to models.
+``GenericTaggedItemBase``       Allows custom ``Tag`` models. Tagged models use an integer primary key.
+``GenericUUIDTaggedItemBase``   Allows custom ``Tag`` models. Tagged models use a UUID primary key.
+``CommonGenericTaggedItemBase`` Allows custom ``Tag`` models and ``GenericForeignKeys`` to models.
+``ItemBase``                    Allows custom ``Tag`` models and ``ForeignKeys`` to models.
+=============================== =======================================================================
+
+Custom ForeignKeys
+~~~~~~~~~~~~~~~~~~
+
 Your intermediary model must be a subclass of
 ``taggit.models.TaggedItemBase`` with a foreign key to your content
 model named ``content_object``. Pass this intermediary model as the
@@ -32,16 +48,66 @@ model named ``content_object``. Pass this intermediary model as the
 
 Once this is done, the API works the same as for GFK-tagged models.
 
-To change the behavior in other ways there are a number of other classes you
-can subclass to obtain different behavior:
+Custom GenericForeignKeys
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-========================= ===========================================================
-Class name                Behavior
-========================= ===========================================================
-``TaggedItemBase``        Allows custom ``ForeignKeys`` to models.
-``GenericTaggedItemBase`` Allows custom ``Tag`` models.
-``ItemBase``              Allows custom ``Tag`` models and ``ForeignKeys`` to models.
-========================= ===========================================================
+The default ``GenericForeignKey`` used by ``django-taggit`` assume your
+tagged object use an integer primary key. For non-integer primary key,
+your intermediary model must be a subclass of ``taggit.models.CommonGenericTaggedItemBase``
+with a field named ``"object_id"`` of the type of your primary key.
+
+For example, if your primary key is a string::
+
+    from django.db import models
+
+    from taggit.managers import TaggableManager
+    from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
+
+    class GenericStringTaggedItem(CommonGenericTaggedItemBase, TaggedItemBase):
+        object_id = models.CharField(max_length=50, verbose_name=_('Object id'), db_index=True)
+
+    class Food(models.Model):
+        food_id = models.CharField(primary_key=True)
+        # ... fields here
+
+        tags = TaggableManager(through=GenericStringTaggedItem)
+
+GenericUUIDTaggedItemBase
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    ``GenericUUIDTaggedItemBase`` relies on Django UUIDField introduced with
+    Django 1.8. Therefore ``GenericUUIDTaggedItemBase`` is only defined
+    if you are using Django 1.8+.
+
+A common use case of a non-integer primary key, is UUID primary key.
+``django-taggit`` provides a base class ``GenericUUIDTaggedItemBase`` ready
+to use with models using an UUID primary key::
+
+    from django.db import models
+    from django.utils.translation import ugettext_lazy as _
+
+    from taggit.managers import TaggableManager
+    from taggit.models import GenericUUIDTaggedItemBase, TaggedItemBase
+
+    class UUIDTaggedItem(GenericUUIDTaggedItemBase, TaggedItemBase):
+        # If you only inherit GenericUUIDTaggedItemBase, you need to define
+        # a tag field. e.g.
+        # tag = models.ForeignKey(Tag, related_name="uuid_tagged_items", on_delete=models.CASCADE)
+
+        class Meta:
+            verbose_name = _("Tag")
+            verbose_name_plural = _("Tags")
+
+    class Food(models.Model):
+        id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+        # ... fields here
+
+        tags = TaggableManager(through=UUIDTaggedItem)
+
+Custom tag
+~~~~~~~~~~
 
 When providing a custom ``Tag`` model it should be a ``ForeignKey`` to your tag
 model named ``"tag"``:

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -26,7 +26,7 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
 from taggit.forms import TagField
-from taggit.models import GenericTaggedItemBase, TaggedItem
+from taggit.models import CommonGenericTaggedItemBase, TaggedItem
 from taggit.utils import _get_field, require_instance_manager
 
 try:
@@ -124,7 +124,7 @@ class _TaggableManager(models.Manager):
         from django.db import connections
         db = self._db or router.db_for_read(instance.__class__, instance=instance)
 
-        fieldname = ('object_id' if issubclass(self.through, GenericTaggedItemBase)
+        fieldname = ('object_id' if issubclass(self.through, CommonGenericTaggedItemBase)
                      else 'content_object')
         fk = self.through._meta.get_field(fieldname)
         query = {
@@ -392,7 +392,7 @@ class TaggableManager(RelatedField, Field):
             self.related = RelatedObject(cls, self.model, self)
 
         self.use_gfk = (
-            self.through is None or issubclass(self.through, GenericTaggedItemBase)
+            self.through is None or issubclass(self.through, CommonGenericTaggedItemBase)
         )
 
         # rel.to renamed to remote_field.model in Django 1.9

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import django
+from django import VERSION
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, models, transaction
 from django.db.models.query import QuerySet
@@ -151,8 +152,7 @@ class TaggedItemBase(ItemBase):
         return cls.tag_model().objects.filter(**kwargs).distinct()
 
 
-class GenericTaggedItemBase(ItemBase):
-    object_id = models.IntegerField(verbose_name=_('Object id'), db_index=True)
+class CommonGenericTaggedItemBase(ItemBase):
     content_type = models.ForeignKey(
         ContentType,
         on_delete=models.CASCADE,
@@ -197,6 +197,22 @@ class GenericTaggedItemBase(ItemBase):
         if extra_filters:
             kwargs.update(extra_filters)
         return cls.tag_model().objects.filter(**kwargs).distinct()
+
+
+class GenericTaggedItemBase(CommonGenericTaggedItemBase):
+    object_id = models.IntegerField(verbose_name=_('Object id'), db_index=True)
+
+    class Meta:
+        abstract = True
+
+
+if VERSION >= (1, 8):
+
+    class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
+        object_id = models.UUIDField(verbose_name=_('Object id'), db_index=True)
+
+        class Meta:
+            abstract = True
 
 
 class TaggedItem(GenericTaggedItemBase, TaggedItemBase):

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django import forms, VERSION
 
-from .models import CustomPKFood, DirectFood, Food, OfficialFood
+from .models import (CustomPKFood, DirectCustomPKFood, DirectFood, Food,
+                     OfficialFood)
 
 fields = None
 if VERSION >= (1, 6):
@@ -17,6 +18,11 @@ class FoodForm(forms.ModelForm):
 class DirectFoodForm(forms.ModelForm):
     class Meta:
         model = DirectFood
+        fields = fields
+
+class DirectCustomPKFoodForm(forms.ModelForm):
+    class Meta:
+        model = DirectCustomPKFood
         fields = fields
 
 class CustomPKFoodForm(forms.ModelForm):

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -62,6 +62,34 @@ class Migration(migrations.Migration):
             bases=('tests.custompkpet',),
         ),
         migrations.CreateModel(
+            name='DirectCustomPKFood',
+            fields=[
+                ('name', models.CharField(help_text='', max_length=50, serialize=False, primary_key=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='DirectCustomPKPet',
+            fields=[
+                ('name', models.CharField(help_text='', max_length=50, serialize=False, primary_key=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='DirectCustomPKHousePet',
+            fields=[
+                ('directcustompkpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.DirectCustomPKPet', help_text='')),
+                ('trained', models.BooleanField(default=False, help_text='')),
+            ],
+            options={
+            },
+            bases=('tests.directcustompkpet',),
+        ),
+        migrations.CreateModel(
             name='DirectFood',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
@@ -238,10 +266,23 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
+            name='TaggedCustomPK',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
+                ('object_id', models.CharField(help_text='', max_length=50, verbose_name='Object id', db_index=True)),
+                ('content_type', models.ForeignKey(related_name='tests_taggedcustompk_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_taggedcustompk_items', to='taggit.Tag', help_text='')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
             name='TaggedCustomPKFood',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.CustomPKFood')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKFood')),
                 ('tag', models.ForeignKey(related_name='tests_taggedcustompkfood_items', to='taggit.Tag', help_text='')),
             ],
             options={
@@ -253,7 +294,7 @@ class Migration(migrations.Migration):
             name='TaggedCustomPKPet',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.CustomPKPet')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKPet')),
                 ('tag', models.ForeignKey(related_name='tests_taggedcustompkpet_items', to='taggit.Tag', help_text='')),
             ],
             options={
@@ -365,6 +406,18 @@ class Migration(migrations.Migration):
             preserve_default=True,
         ),
         migrations.AddField(
+            model_name='custompkpet',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomPK', help_text='A comma-separated list of tags.', verbose_name='Tags'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='custompkfood',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomPK', help_text='A comma-separated list of tags.', verbose_name='Tags'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
             model_name='directpet',
             name='tags',
             field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedPet', help_text='A comma-separated list of tags.', verbose_name='Tags'),
@@ -377,13 +430,13 @@ class Migration(migrations.Migration):
             preserve_default=True,
         ),
         migrations.AddField(
-            model_name='custompkpet',
+            model_name='directcustompkpet',
             name='tags',
             field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomPKPet', help_text='A comma-separated list of tags.', verbose_name='Tags'),
             preserve_default=True,
         ),
         migrations.AddField(
-            model_name='custompkfood',
+            model_name='directcustompkfood',
             name='tags',
             field=taggit.managers.TaggableManager(to='taggit.Tag', through='tests.TaggedCustomPKFood', help_text='A comma-separated list of tags.', verbose_name='Tags'),
             preserve_default=True,

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,8 +4,8 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
 from taggit.managers import TaggableManager
-from taggit.models import (GenericTaggedItemBase, Tag, TagBase, TaggedItem,
-                           TaggedItemBase)
+from taggit.models import (CommonGenericTaggedItemBase, GenericTaggedItemBase,
+                           Tag, TagBase, TaggedItem, TaggedItemBase)
 
 
 # Ensure that two TaggableManagers with custom through model are allowed.
@@ -90,13 +90,13 @@ class DirectHousePet(DirectPet):
 # Test custom through model to model with custom PK
 
 class TaggedCustomPKFood(TaggedItemBase):
-    content_object = models.ForeignKey('CustomPKFood')
+    content_object = models.ForeignKey('DirectCustomPKFood')
 
 class TaggedCustomPKPet(TaggedItemBase):
-    content_object = models.ForeignKey('CustomPKPet')
+    content_object = models.ForeignKey('DirectCustomPKPet')
 
 @python_2_unicode_compatible
-class CustomPKFood(models.Model):
+class DirectCustomPKFood(models.Model):
     name = models.CharField(max_length=50, primary_key=True)
 
     tags = TaggableManager(through=TaggedCustomPKFood)
@@ -105,10 +105,36 @@ class CustomPKFood(models.Model):
         return self.name
 
 @python_2_unicode_compatible
-class CustomPKPet(models.Model):
+class DirectCustomPKPet(models.Model):
     name = models.CharField(max_length=50, primary_key=True)
 
     tags = TaggableManager(through=TaggedCustomPKPet)
+
+    def __str__(self):
+        return self.name
+
+class DirectCustomPKHousePet(DirectCustomPKPet):
+    trained = models.BooleanField(default=False)
+
+# Test custom through model to model with custom PK using GenericForeignKey
+
+class TaggedCustomPK(CommonGenericTaggedItemBase, TaggedItemBase):
+    object_id = models.CharField(max_length=50, verbose_name='Object id', db_index=True)
+
+@python_2_unicode_compatible
+class CustomPKFood(models.Model):
+    name = models.CharField(max_length=50, primary_key=True)
+
+    tags = TaggableManager(through=TaggedCustomPK)
+
+    def __str__(self):
+        return self.name
+
+@python_2_unicode_compatible
+class CustomPKPet(models.Model):
+    name = models.CharField(max_length=50, primary_key=True)
+
+    tags = TaggableManager(through=TaggedCustomPK)
 
     def __str__(self):
         return self.name

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,14 +11,16 @@ from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 from django.utils.encoding import force_text
 
-from .forms import CustomPKFoodForm, DirectFoodForm, FoodForm, OfficialFoodForm
+from .forms import (CustomPKFoodForm, DirectCustomPKFoodForm, DirectFoodForm,
+                    FoodForm, OfficialFoodForm)
 from .models import (Article, Child, CustomManager, CustomPKFood,
-                     CustomPKHousePet, CustomPKPet, DirectFood,
+                     CustomPKHousePet, CustomPKPet, DirectCustomPKFood,
+                     DirectCustomPKHousePet, DirectCustomPKPet, DirectFood,
                      DirectHousePet, DirectPet, Food, HousePet, Movie,
                      OfficialFood, OfficialHousePet, OfficialPet,
                      OfficialTag, OfficialThroughModel, Pet, Photo,
-                     TaggedCustomPKFood, TaggedCustomPKPet, TaggedFood,
-                     TaggedPet)
+                     TaggedCustomPK, TaggedCustomPKFood, TaggedCustomPKPet,
+                     TaggedFood, TaggedPet)
 
 from taggit.managers import _model_name, _TaggableManager, TaggableManager
 from taggit.models import Tag, TaggedItem
@@ -100,6 +102,10 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
 
 class TagModelDirectTestCase(TagModelTestCase):
     food_model = DirectFood
+    tag_model = Tag
+
+class TagModelDirectCustomPKTestCase(TagModelTestCase):
+    food_model = DirectCustomPKFood
     tag_model = Tag
 
 class TagModelCustomPKTestCase(TagModelTestCase):
@@ -404,11 +410,22 @@ class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     housepet_model = DirectHousePet
     taggeditem_model = TaggedFood
 
+class TaggableManagerDirectCustomPKTestCase(TaggableManagerTestCase):
+    food_model = DirectCustomPKFood
+    pet_model = DirectCustomPKPet
+    housepet_model = DirectCustomPKHousePet
+    taggeditem_model = TaggedCustomPKFood
+
+    def test_require_pk(self):
+        # TODO with a charfield pk, pk is never None, so taggit has no way to
+        # tell if the instance is saved or not
+        pass
+
 class TaggableManagerCustomPKTestCase(TaggableManagerTestCase):
     food_model = CustomPKFood
     pet_model = CustomPKPet
     housepet_model = CustomPKHousePet
-    taggeditem_model = TaggedCustomPKFood
+    taggeditem_model = TaggedCustomPK
 
     def test_require_pk(self):
         # TODO with a charfield pk, pk is never None, so taggit has no way to
@@ -506,6 +523,10 @@ class TaggableFormTestCase(BaseTaggingTestCase):
 class TaggableFormDirectTestCase(TaggableFormTestCase):
     form_class = DirectFoodForm
     food_model = DirectFood
+
+class TaggableFormDirectCustomPKTestCase(TaggableFormTestCase):
+    form_class = DirectCustomPKFoodForm
+    food_model = DirectCustomPKFood
 
 class TaggableFormCustomPKTestCase(TaggableFormTestCase):
     form_class = CustomPKFoodForm


### PR DESCRIPTION
This pull request makes possible to use Django-taggit on any models with non-integer primary-key without the need to define one Through Model per tagged model (e.g. using GenericForeignKey not direct ForeignKey).

I moved the common code from GenericTaggedItemBase to a new CommonGenericTaggedItemBase class.

User may then inherit from CommonGenericTaggedItemBase to define a Through Model for custom PK while still using GenericForeignKey.

I've updated the doc to include example of a non-integer primary key and added test.

I've also included a GenericUUIDTaggedItemBase which is the same as GenericTaggedItemBase but for UUID primary-key (since it's probably the most common use case). But since it rely on Django 1.8, it's only defined for Django 1.8+