### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 sudo: false
 env:
-  - TOXENV=py26-1.4.x
-  - TOXENV=py26-1.5.x
-  - TOXENV=py26-1.6.x
   - TOXENV=py27-1.4.x
   - TOXENV=py27-1.5.x
   - TOXENV=py27-1.6.x

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+HEAD
+~~~~
+ * Drop support for Python 2.6
+  * https://github.com/alex/django-taggit/pull/373
+
 0.17.6 (2015-12-09)
 ~~~~~~~~~~~~~~~~~~~
  * Silence Django 1.9 warning

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -20,24 +20,6 @@ commands =
 	python ./runtests.py {posargs}
 
 
-[testenv:py26-1.4.x]
-basepython = python2.6
-deps =
-	{[testenv]deps}
-	{[testenv]deps14}
-
-[testenv:py26-1.5.x]
-basepython = python2.6
-deps =
-	{[testenv]deps}
-	{[testenv]deps15}
-
-[testenv:py26-1.6.x]
-basepython = python2.6
-deps =
-	{[testenv]deps}
-	{[testenv]deps16}
-
 [testenv:py27-1.4.x]
 basepython = python2.7
 deps =


### PR DESCRIPTION
Python 2.6 has been officially unsupported for quite some time. In
addition, no maintained versions of Django support Python 2.6. There's
no reason we should be maintaining compatibility for unmaintained and
unsecure versions of Python.