### PR TITLE
Fix all deprecation warnings

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys
+import warnings
 
 from django.conf import settings
 from django.core.management import execute_from_command_line
@@ -19,6 +20,10 @@ if not settings.configured:
         ],
         MIDDLEWARE_CLASSES=[],
     )
+
+
+warnings.simplefilter('default', DeprecationWarning)
+warnings.simplefilter('default', PendingDeprecationWarning)
 
 
 def runtests():

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -89,6 +89,10 @@ class ExtraJoinRestriction(object):
         self.content_types = content_types
 
     def as_sql(self, qn, connection):
+        # qn changed from a quoting function to be a compiler object in 1.8,
+        # which has a quote function
+        if VERSION >= (1, 8):
+            qn = qn.quote_name_unless_alias
         if len(self.content_types) == 1:
             extra_where = "%s.%s = %%s" % (qn(self.alias), qn(self.col))
         else:

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -49,7 +49,7 @@ except ImportError:  # Django < 1.8
 
 
 def _model_name(model):
-    if VERSION < (1, 7):
+    if VERSION < (1, 6):
         return model._meta.module_name
     else:
         return model._meta.model_name

--- a/taggit/utils.py
+++ b/taggit/utils.py
@@ -16,6 +16,20 @@ def _get_field(model, name):
         return model._meta.get_field(name)
 
 
+def _remote_field(field):
+    if VERSION < (1, 9):
+        return field.rel
+    else:
+        return field.remote_field
+
+
+def _related_model(remote_field):
+    if VERSION >= (1, 9):
+        return remote_field.model
+    else:
+        return remote_field.to
+
+
 def _parse_tags(tagstring):
     """
     Parses tag input, with multiple word input being activated and

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CustomPKHousePet',
             fields=[
-                ('custompkpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.CustomPKPet', help_text='')),
+                ('custompkpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.CustomPKPet', help_text='', on_delete=models.CASCADE)),
                 ('trained', models.BooleanField(default=False, help_text='')),
             ],
             options={
@@ -82,7 +82,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='DirectCustomPKHousePet',
             fields=[
-                ('directcustompkpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.DirectCustomPKPet', help_text='')),
+                ('directcustompkpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.DirectCustomPKPet', help_text='', on_delete=models.CASCADE)),
                 ('trained', models.BooleanField(default=False, help_text='')),
             ],
             options={
@@ -112,7 +112,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='DirectHousePet',
             fields=[
-                ('directpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.DirectPet', help_text='')),
+                ('directpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.DirectPet', help_text='', on_delete=models.CASCADE)),
                 ('trained', models.BooleanField(default=False, help_text='')),
             ],
             options={
@@ -183,7 +183,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='OfficialHousePet',
             fields=[
-                ('officialpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.OfficialPet', help_text='')),
+                ('officialpet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.OfficialPet', help_text='', on_delete=models.CASCADE)),
                 ('trained', models.BooleanField(default=False, help_text='')),
             ],
             options={
@@ -208,8 +208,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
                 ('object_id', models.IntegerField(help_text='', verbose_name='Object id', db_index=True)),
-                ('content_type', models.ForeignKey(related_name='tests_officialthroughmodel_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='')),
-                ('tag', models.ForeignKey(related_name='tagged_items', to='tests.OfficialTag', help_text='')),
+                ('content_type', models.ForeignKey(related_name='tests_officialthroughmodel_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tagged_items', to='tests.OfficialTag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -228,7 +228,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Child',
             fields=[
-                ('parent_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Parent', help_text='')),
+                ('parent_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Parent', help_text='', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -247,7 +247,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='HousePet',
             fields=[
-                ('pet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Pet', help_text='')),
+                ('pet_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Pet', help_text='', on_delete=models.CASCADE)),
                 ('trained', models.BooleanField(default=False, help_text='')),
             ],
             options={
@@ -271,7 +271,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
                 ('object_id', models.CharField(help_text='', max_length=50, verbose_name='Object id', db_index=True)),
                 ('content_type', models.ForeignKey(related_name='tests_taggedcustompk_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='', on_delete=models.CASCADE)),
-                ('tag', models.ForeignKey(related_name='tests_taggedcustompk_items', to='taggit.Tag', help_text='')),
+                ('tag', models.ForeignKey(related_name='tests_taggedcustompk_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -282,8 +282,8 @@ class Migration(migrations.Migration):
             name='TaggedCustomPKFood',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKFood')),
-                ('tag', models.ForeignKey(related_name='tests_taggedcustompkfood_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKFood', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_taggedcustompkfood_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -294,8 +294,8 @@ class Migration(migrations.Migration):
             name='TaggedCustomPKPet',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKPet')),
-                ('tag', models.ForeignKey(related_name='tests_taggedcustompkpet_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectCustomPKPet', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_taggedcustompkpet_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -306,8 +306,8 @@ class Migration(migrations.Migration):
             name='TaggedFood',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.DirectFood')),
-                ('tag', models.ForeignKey(related_name='tests_taggedfood_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectFood', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_taggedfood_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -318,8 +318,8 @@ class Migration(migrations.Migration):
             name='TaggedPet',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.DirectPet')),
-                ('tag', models.ForeignKey(related_name='tests_taggedpet_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.DirectPet', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_taggedpet_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -330,8 +330,8 @@ class Migration(migrations.Migration):
             name='Through1',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.MultipleTags')),
-                ('tag', models.ForeignKey(related_name='tests_through1_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.MultipleTags', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_through1_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -342,8 +342,8 @@ class Migration(migrations.Migration):
             name='Through2',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
-                ('content_object', models.ForeignKey(help_text='', to='tests.MultipleTags')),
-                ('tag', models.ForeignKey(related_name='tests_through2_items', to='taggit.Tag', help_text='')),
+                ('content_object', models.ForeignKey(help_text='', to='tests.MultipleTags', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tests_through2_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -355,8 +355,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, help_text='', verbose_name='ID')),
                 ('object_id', models.IntegerField(help_text='', verbose_name='Object id', db_index=True)),
-                ('content_type', models.ForeignKey(related_name='tests_throughgfk_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='')),
-                ('tag', models.ForeignKey(related_name='tagged_items', to='taggit.Tag', help_text='')),
+                ('content_type', models.ForeignKey(related_name='tests_throughgfk_tagged_items', verbose_name='Content type', to='contenttypes.ContentType', help_text='', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='tagged_items', to='taggit.Tag', help_text='', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,11 +10,11 @@ from taggit.models import (CommonGenericTaggedItemBase, GenericTaggedItemBase,
 
 # Ensure that two TaggableManagers with custom through model are allowed.
 class Through1(TaggedItemBase):
-    content_object = models.ForeignKey('MultipleTags')
+    content_object = models.ForeignKey('MultipleTags', on_delete=models.CASCADE)
 
 
 class Through2(TaggedItemBase):
-    content_object = models.ForeignKey('MultipleTags')
+    content_object = models.ForeignKey('MultipleTags', on_delete=models.CASCADE)
 
 
 class MultipleTags(models.Model):
@@ -23,7 +23,7 @@ class MultipleTags(models.Model):
 
 # Ensure that two TaggableManagers with GFK via different through models are allowed.
 class ThroughGFK(GenericTaggedItemBase):
-    tag = models.ForeignKey(Tag, related_name='tagged_items')
+    tag = models.ForeignKey(Tag, related_name='tagged_items', on_delete=models.CASCADE)
 
 class MultipleTagsGFK(models.Model):
     tags1 = TaggableManager(related_name='tagsgfk1')
@@ -56,11 +56,11 @@ class HousePet(Pet):
 # Test direct-tagging with custom through model
 
 class TaggedFood(TaggedItemBase):
-    content_object = models.ForeignKey('DirectFood')
+    content_object = models.ForeignKey('DirectFood', on_delete=models.CASCADE)
 
 
 class TaggedPet(TaggedItemBase):
-    content_object = models.ForeignKey('DirectPet')
+    content_object = models.ForeignKey('DirectPet', on_delete=models.CASCADE)
 
 
 @python_2_unicode_compatible
@@ -90,10 +90,10 @@ class DirectHousePet(DirectPet):
 # Test custom through model to model with custom PK
 
 class TaggedCustomPKFood(TaggedItemBase):
-    content_object = models.ForeignKey('DirectCustomPKFood')
+    content_object = models.ForeignKey('DirectCustomPKFood', on_delete=models.CASCADE)
 
 class TaggedCustomPKPet(TaggedItemBase):
-    content_object = models.ForeignKey('DirectCustomPKPet')
+    content_object = models.ForeignKey('DirectCustomPKPet', on_delete=models.CASCADE)
 
 @python_2_unicode_compatible
 class DirectCustomPKFood(models.Model):
@@ -148,7 +148,7 @@ class OfficialTag(TagBase):
     official = models.BooleanField(default=False)
 
 class OfficialThroughModel(GenericTaggedItemBase):
-    tag = models.ForeignKey(OfficialTag, related_name="tagged_items")
+    tag = models.ForeignKey(OfficialTag, related_name="tagged_items", on_delete=models.CASCADE)
 
 @python_2_unicode_compatible
 class OfficialFood(models.Model):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -705,4 +705,4 @@ class DjangoCheckTests(UnitTestCase):
         if django.VERSION >= (1, 6):
             call_command('check', tag=['models'])
         else:
-                    call_command('validate')
+            call_command('validate')


### PR DESCRIPTION
I've fixed all deprecation warnings from all versions of Django supported by taggit, while maintaining backwards compatibility with all currently supported versions, and with all tests passing.

This involved adding some helpers for the recently renamed `field.rel.to`/`field.remote_field.model`, and changing the use of `add_lazy_relation` to `lazy_related_operation` on Django 1.9.

SQL names are quoted using the correct function now, fixing #380 and #383.

`on_delete=models.CASCADE` has been added to all ForeignKeys where it was missing, including in tests and migrations. This is backwards compatible with current code and projects, as `on_delete=models.CASCADE` was the assumed default previously.

Warnings due to different versions of unittest bundled through different version of Django have been sorted out, as has a warning from Django for Python 3.3, 3.4.

Finally, DeprecationWarnings are now show in test output. As there are no more deprecation warnings, the test output is still useable as it is before, without being polluted with lots of DeprecationWarning noise.