### PR TITLE
Fix #384: Do not be treated as ManyToManyField in the admin

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -283,7 +283,7 @@ class _TaggableManager(models.Manager):
 
 class TaggableManager(RelatedField, Field):
     # Field flags
-    many_to_many = True
+    many_to_many = False
     many_to_one = False
     one_to_many = False
     one_to_one = False


### PR DESCRIPTION
Before commit 983c158d in django, BaseModelAdmin would rely on
db_field.formfield() to generate the form field. After commit 983c158d
in Django, BaseModelAdmin.formfield_for_manytomany() is enabled for
fields with many_to_many=True.

In the case of taggit, this returns None, causing the field to be
ignored by ModelForm::

    django/contrib/admin/options.py(150)formfield_for_dbfield()
        149             elif db_field.many_to_many:
    --> 150                 formfield = self.formfield_for_manytomany(db_field, request, **kwargs)

    django/contrib/admin/options.py(169)formfield_for_dbfield()
    --> 169             return formfield

    > django/forms/models.py(182)fields_for_model()
    --> 182         if formfield:
        183             field_list.append((f.name, formfield))

    ipdb>
    > django/forms/models.py(185)fields_for_model()
        184         else:
    --> 185             ignored.append(f.name)

This patch sets many_to_many=False in taggit, so that it's not treated
as a ManyToManyField by BaseModelAdmin.formfield_for_dbfield(), like
before django's commit 983c158d.

https://github.com/django/django/commit/983c158da7723eb00a376bd31db76709da4d0260