### PR TITLE
Fix TagWidget for newer Django.

### DIFF
--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -10,8 +10,7 @@ from taggit.utils import edit_string_for_tags, parse_tags
 class TagWidget(forms.TextInput):
     def render(self, name, value, attrs=None):
         if value is not None and not isinstance(value, six.string_types):
-            value = edit_string_for_tags([
-                o.tag for o in value.select_related("tag")])
+            value = edit_string_for_tags(o.tag for o in value)
         return super(TagWidget, self).render(name, value, attrs)
 
 


### PR DESCRIPTION
Django's model_to_dict passes many-to-many values to forms as lists, not
QuyerSets. Therefore, cannot use select_related.