### PR TITLE
Fix incorrect args in custom tagging example

### DIFF
--- a/docs/custom_tagging.txt
+++ b/docs/custom_tagging.txt
@@ -191,7 +191,7 @@ a list of tags to a string representation and use the setting
 ``TAGGIT_STRING_FROM_TAGS`` to override the default value (which is
 :func:`taggit.utils._edit_string_for_tags`)::
 
-    def comma_joiner(tag_string):
+    def comma_joiner(tags):
         return ', '.join(t.name for t in tags)
 
 If the functions above were defined in a module, ``appname.utils``, then your


### PR DESCRIPTION
Original code example declares `tag_string` as the argument for `comma_joiner`, however, the body of `comma_joiner` expects an iterable of `Tag` objects named `tags`.