### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -178,7 +178,7 @@ Changelog
  * Added a Hebrew locale.
  * Added an index on the ``object_id`` field of ``TaggedItem``.
  * When displaying tags always join them with commas, never spaces.
- * The docs are now available `online <http://django-taggit.readthedocs.org/>`_.
+ * The docs are now available `online <https://django-taggit.readthedocs.io/>`_.
  * Custom ``Tag`` models are now allowed.
  * **Backwards incompatible:**  Filtering on tags is no longer
    ``filter(tags__in=["foo"])``, it is written

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,6 @@ Tags will show up for you automatically in forms and the admin.
 
 ``django-taggit`` requires Django 1.4.5 or greater.
 
-For more info check out the `documentation <https://django-taggit.readthedocs.org/en/latest/>`_.  And for questions about usage or
+For more info check out the `documentation <https://django-taggit.readthedocs.io/en/latest/>`_.  And for questions about usage or
 development you can contact the
 `mailinglist <http://groups.google.com/group/django-taggit>`_.

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -42,4 +42,4 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-__ http://south.readthedocs.org/en/latest/
+__ https://south.readthedocs.io/en/latest/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.