### PR TITLE
Fix UnboundLocalError in _TaggableManager.set(..)

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -288,8 +288,8 @@ class _TaggableManager(models.Manager):
                 else:
                     new_objs.append(obj)
 
-        self.remove(*old_tag_strs)
-        self.add(*new_objs)
+            self.remove(*old_tag_strs)
+            self.add(*new_objs)
 
     @require_instance_manager
     def remove(self, *tags):


### PR DESCRIPTION
Calling .set(..) with clear=True on an instance manager would produce an
UnboundLocalError. This behavior was introduced in
6542a702b590a5cfb91ea0de218b7f71ffd07c33. This commit fixes the issue,
and adds a separate test to test the behavior of .set(..) with
clear=True.