### PR TITLE
Django 1.9 app_label

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -100,6 +100,7 @@ class Tag(TagBase):
     class Meta:
         verbose_name = _("Tag")
         verbose_name_plural = _("Tags")
+        app_label = 'taggit'
 
 
 @python_2_unicode_compatible
@@ -223,6 +224,7 @@ class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
     class Meta:
         verbose_name = _("Tagged Item")
         verbose_name_plural = _("Tagged Items")
+        app_label = 'taggit'
         if django.VERSION >= (1, 5):
             index_together = [
                 ["content_type", "object_id"],


### PR DESCRIPTION
Adding app_label to Tag and TaggedItems models for Django 1.9 compatibility. Without specifying an app_label you MUST add taggit to INSTALLED_APPS, which you may not want to do if you plan to  customize the models.

#330 