### PR TITLE
Add missing TEMPLATES settings to runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -18,6 +18,12 @@ if not settings.configured:
             'tests',
         ],
         MIDDLEWARE_CLASSES=[],
+        TEMPLATES = [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'APP_DIRS': True,
+            }
+        ],
     )
 
 


### PR DESCRIPTION
When running testsuite using `runtests.py` I get following error due to missing TEMPLATES setting:

```pytb
Traceback (most recent call last):
  File "/build/django-taggit-0.21.3/tests/tests.py", line 996, in test_list_view_returns_single
    response = self.client.get('/food/tags/{}/'.format(self.slug))
  File "/usr/lib/python2.7/dist-packages/django/test/client.py", line 529, in get
    **extra)
  File "/usr/lib/python2.7/dist-packages/django/test/client.py", line 333, in get
    return self.generic('GET', path, secure=secure, **r)
  File "/usr/lib/python2.7/dist-packages/django/test/client.py", line 409, in generic
    return self.request(**r)
  File "/usr/lib/python2.7/dist-packages/django/test/client.py", line 494, in request
    six.reraise(*exc_info)
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 217, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 215, in _get_response
    response = response.render()
  File "/usr/lib/python2.7/dist-packages/django/template/response.py", line 109, in render
    self.content = self.rendered_content
  File "/usr/lib/python2.7/dist-packages/django/template/response.py", line 84, in rendered_content
    template = self.resolve_template(self.template_name)
  File "/usr/lib/python2.7/dist-packages/django/template/response.py", line 66, in resolve_template
    return select_template(template, using=self.using)
  File "/usr/lib/python2.7/dist-packages/django/template/loader.py", line 53, in select_template
    raise TemplateDoesNotExist(', '.join(template_name_list), chain=chain)
TemplateDoesNotExist: tests/food_tag_list.html
```