### PR TITLE
Add __gt__ and __lt__ overrides for TagBase.

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -27,6 +27,12 @@ class TagBase(models.Model):
     def __str__(self):
         return self.name
 
+    def __gt__(self, other):
+        return self.name > other.name
+
+    def __lt__(self, other):
+        return self.name < other.name
+
     class Meta:
         abstract = True
 


### PR DESCRIPTION
Fixes an incompatibility with django-modelcluster and, by extension, Wagtail.

Currently untested, just committing the change to 'save' it.