### PR TITLE
Support __gt__ and __lt__ ordering on Tags

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -27,6 +27,12 @@ class TagBase(models.Model):
     def __str__(self):
         return self.name
 
+    def __gt__(self, other):
+        return self.name.lower() > other.name.lower()
+
+    def __lt__(self, other):
+        return self.name.lower() < other.name.lower()
+
     class Meta:
         abstract = True
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,6 +110,18 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
                 r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
             apple.tags.add(1)
 
+    def test_gt(self):
+        high = self.tag_model.objects.create(name='high')
+        low = self.tag_model.objects.create(name='Low')
+        self.assertTrue(low > high)
+        self.assertFalse(high > low)
+
+    def test_lt(self):
+        high = self.tag_model.objects.create(name='high')
+        low = self.tag_model.objects.create(name='Low')
+        self.assertTrue(high < low)
+        self.assertFalse(low < high)
+
 
 class TagModelDirectTestCase(TagModelTestCase):
     food_model = DirectFood


### PR DESCRIPTION
This makes it possible to call `sort()` on a list of `Tag` objects in memory.