### PR TITLE
Fix case-insensitive tag creation when setting to a mix of new and existing tags are used

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -223,7 +223,7 @@ class _TaggableManager(models.Manager):
         for new_tag in tags_to_create:
             if case_insensitive:
                 try:
-                    tag = manager.get(name__iexact=name)
+                    tag = manager.get(name__iexact=new_tag)
                 except self.through.tag_model().DoesNotExist:
                     tag = manager.create(name=new_tag)
             else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import sys
 import warnings
 from unittest import TestCase as UnitTestCase
-from unittest import skipIf, skipUnless
+from unittest import expectedFailure, skipIf, skipUnless
 
 import django
 import mock
@@ -674,6 +674,17 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         orange.tags.add('spain', 'Spain')
         tag_names = list(orange.tags.names())
         self.assertEqual(len(tag_names), 1, tag_names)
+
+    @override_settings(TAGGIT_CASE_INSENSITIVE=True)
+    @expectedFailure
+    def test_with_case_insensitive_option_new_and_old(self):
+        orange = self.food_model.objects.create(name="orange")
+        orange.tags.add('Spain')
+        tag_names = list(orange.tags.names())
+        self.assertEqual(len(tag_names), 1, tag_names)
+        orange.tags.add('spain', 'Valencia')
+        tag_names = sorted(orange.tags.names())
+        self.assertEqual(tag_names, ['Spain', 'Valencia'])
 
 
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import sys
 import warnings
 from unittest import TestCase as UnitTestCase
-from unittest import expectedFailure, skipIf, skipUnless
+from unittest import skipIf, skipUnless
 
 import django
 import mock
@@ -676,7 +676,6 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         self.assertEqual(len(tag_names), 1, tag_names)
 
     @override_settings(TAGGIT_CASE_INSENSITIVE=True)
-    @expectedFailure
     def test_with_case_insensitive_option_new_and_old(self):
         orange = self.food_model.objects.create(name="orange")
         orange.tags.add('Spain')


### PR DESCRIPTION
Demonstrates and fixes bug #463, which was introduced by my last PR #461.