### PR TITLE
Drop support for Django 1.7 and remove all workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,14 @@ language: python
 sudo: false
 matrix:
   include:
-    - env: TOXENV=py27-1.7.x
-      python: 2.7
     - env: TOXENV=py27-1.8.x
       python: 2.7
     - env: TOXENV=py27-1.9.x
       python: 2.7
     - env: TOXENV=py27-1.10.x
       python: 2.7
-    - env: TOXENV=py33-1.7.x
-      python: 3.3
     - env: TOXENV=py33-1.8.x
       python: 3.3
-    - env: TOXENV=py34-1.7.x
-      python: 3.4
     - env: TOXENV=py34-1.8.x
       python: 3.4
     - env: TOXENV=py34-1.9.x

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+UNRELEASED
+~~~~~~~~~~
+ * **Backwards incompatible:** Drop support for Django 1.7
+
 0.21.6 (2017-01-25)
 ~~~~~~~~~~~~~~~~~~~
  * Fix case-insensitive tag creation when setting to a mix of new and existing tags are used

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Then you can use the API like so:
 
 Tags will show up for you automatically in forms and the admin.
 
-``django-taggit`` requires Django 1.7 or greater.
+``django-taggit`` requires Django 1.8 or greater.
 
 For more info check out the `documentation <https://django-taggit.readthedocs.io/en/latest/>`_.  And for questions about usage or
 development you can contact the

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -4,7 +4,7 @@ Welcome to django-taggit's documentation!
 ``django-taggit`` is a reusable Django application designed to making adding
 tagging to your project easy and fun.
 
-``django-taggit`` works with Django 1.7+ and Python 2.7-3.X.
+``django-taggit`` works with Django 1.8+ and Python 2.7-3.X.
 
 .. toctree::
    :maxdepth: 2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-Django
+Django>=1.8
 coverage
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.7',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -10,8 +10,6 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 
-from taggit.utils import _get_field
-
 try:
     from unidecode import unidecode
 except ImportError:
@@ -99,12 +97,12 @@ class ItemBase(models.Model):
 
     @classmethod
     def tag_model(cls):
-        field = _get_field(cls, 'tag')
+        field = cls._meta.get_field('tag')
         return field.remote_field.model if VERSION >= (1, 9) else field.rel.to
 
     @classmethod
     def tag_relname(cls):
-        field = _get_field(cls, 'tag')
+        field = cls._meta.get_field('tag')
         return field.remote_field.related_name if VERSION >= (1, 9) else field.rel.related_name
 
     @classmethod
@@ -194,13 +192,11 @@ class GenericTaggedItemBase(CommonGenericTaggedItemBase):
         abstract = True
 
 
-if VERSION >= (1, 8):
+class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
+    object_id = models.UUIDField(verbose_name=_('Object id'), db_index=True)
 
-    class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
-        object_id = models.UUIDField(verbose_name=_('Object id'), db_index=True)
-
-        class Meta:
-            abstract = True
+    class Meta:
+        abstract = True
 
 
 class TaggedItem(GenericTaggedItemBase, TaggedItemBase):

--- a/taggit/utils.py
+++ b/taggit/utils.py
@@ -9,13 +9,6 @@ from django.utils.encoding import force_text
 from django.utils.functional import wraps
 
 
-def _get_field(model, name):
-    if VERSION < (1, 8):
-        return model._meta.get_field_by_name(name)[0]
-    else:
-        return model._meta.get_field(name)
-
-
 def _remote_field(field):
     if VERSION < (1, 9):
         return field.rel

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -610,13 +610,8 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             self.assertTrue(hasattr(field, 'rel'))
             self.assertTrue(hasattr(field.rel, 'to'))
 
-        # This API has changed in Django 1.8
-        # https://code.djangoproject.com/ticket/21414
-        if django.VERSION >= (1, 8):
-            self.assertEqual(self.food_model, field.model)
-            self.assertEqual(self.tag_model, _remote_field(field).model)
-        else:
-            self.assertEqual(self.food_model, field.related.model)
+        self.assertEqual(self.food_model, field.model)
+        self.assertEqual(self.tag_model, _remote_field(field).model)
 
     def test_names_method(self):
         apple = self.food_model.objects.create(name="apple")
@@ -1026,4 +1021,3 @@ class TagListViewTests(BaseTaggingTestCase, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.apple, response.context_data['object_list'])
         self.assertNotIn(self.strawberry, response.context_data['object_list'])
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 envlist =
-    {py27,py33,py34}-1.7.x
     {py27,py33,py34,py35}-1.8.x
     {py27,py34,py35}-1.9.x
     {py27,py34,py35}-1.10.x
 
 [testenv]
 deps =
-    1.7.x: https://github.com/django/django/archive/stable/1.7.x.tar.gz#egg=django
     1.8.x: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
     1.9.x: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
     1.10.x: https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django


### PR DESCRIPTION
Django 1.7 is no longer supported and has not received security updates since
2015-12-01. This avoids workarounds for potentially insecure and outdated
Django.

See table of Django supported versions:

https://www.djangoproject.com/download/#supported-versions