### PR TITLE
[docs] Added contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+Please see `Contributing to taggit <https://django-taggit.readthedocs.io/en/latest/contributing.html>`_.

--- a/docs/contributing.txt
+++ b/docs/contributing.txt
@@ -1,0 +1,95 @@
+Contributing to taggit
+======================
+
+Thank you for taking the time to contribute to django-taggit.
+
+Follow these guidelines to speed up the process.
+
+.. contents:: **Table of Contents**:
+   :backlinks: none
+   :depth: 3
+
+Reach out before you start
+--------------------------
+
+Before opening a new issue, try the following steps:
+
+- look if somebody else has already started working on the same issue
+  by looking in the `github issues <https://github.com/alex/django-taggit/issues>`_
+  and `pull requests <https://github.com/alex/django-taggit/pulls>`_
+- look also in the `django-taggit mailinglist <http://groups.google.com/group/django-taggit>`_
+- announce your intentions by opening a new issue
+- present yourself on the mailing list
+
+Fork repo and install your fork
+-------------------------------
+
+Once you have forked this repository to your own github account or organization,
+install your own fork in your development environment:
+
+.. code-block:: shell
+
+    git clone git@github.com:<your_fork>/django-taggit.git
+    cd django-taggit
+    python setup.py develop
+
+Running tests
+-------------
+
+.. code-block:: shell
+
+    make test
+
+Opening the django shell
+------------------------
+
+.. code-block:: shell
+
+    ./manage.py shell
+
+Creating new migrations
+---------------------
+
+.. code-block:: shell
+
+    ./manage.py makemigrations
+
+
+Follow style conventions (PEP8, isort)
+--------------------------------------
+
+Check that your changes are not breaking the style conventions with:
+
+.. code-block:: shell
+
+    flake8 taggit
+    python setup.py isort
+
+For more information, please see:
+
+- `PEP8: Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_
+- `isort: a python utility / library to sort imports <https://github.com/timothycrosley/isort>`_
+
+Update documentation
+--------------------
+
+If you introduce new features or change existing documented behavior,
+please remember to update the documentation!
+
+The documentation is located in the ``/docs`` directory
+of the repository.
+
+To do work on the docs, proceed with the following steps:
+
+.. code-block:: shell
+
+    cd docs/
+    pip install sphinx
+    # update the text files with your favorite text editor
+    make html
+
+Send pull request
+-----------------
+
+Now is time to push your changes to github and open a
+`pull request <https://github.com/alex/django-taggit/pulls>`_!

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -14,6 +14,7 @@ tagging to your project easy and fun.
    admin
    api
    custom_tagging
+   contributing
    external_apps
    changelog
 

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'tests.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
- `CONTRIBUTING.rst`: this file is linked automatically
  by github when opening new issues
- `docs/contributing.txt`: contribution guidelines
- `manage.py`: I added a manage.py to make it easier to run django
  commands in the development environment

Regarding `manage.py`, I tried to use the `django-admin` script, but I couldn't get it working.

References issue #479