### PR TITLE
Use set literals and set comprehension

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -107,8 +107,7 @@ class _TaggableManager(models.Manager):
                      else 'content_object')
         fk = self.through._meta.get_field(fieldname)
         query = {
-            '%s__%s__in' % (self.through.tag_relname(), fk.name):
-                set(obj._get_pk_val() for obj in instances)
+            '%s__%s__in' % (self.through.tag_relname(), fk.name): {obj._get_pk_val() for obj in instances}
         }
         join_table = self.through._meta.db_table
         source_col = fk.column
@@ -133,7 +132,7 @@ class _TaggableManager(models.Manager):
         db = router.db_for_write(self.through, instance=self.instance)
 
         tag_objs = self._to_tag_model_instances(tags)
-        new_ids = set(t.pk for t in tag_objs)
+        new_ids = {t.pk for t in tag_objs}
 
         # NOTE: can we hardcode 'tag_id' here or should the column name be got
         # dynamically from somewhere?
@@ -198,7 +197,7 @@ class _TaggableManager(models.Manager):
             # If str_tags has 0 elements Django actually optimizes that to not
             # do a query.  Malcolm is very smart.
             existing = manager.filter(name__in=str_tags)
-            tags_to_create = str_tags - set(t.name for t in existing)
+            tags_to_create = str_tags - {t.name for t in existing}
 
         tag_objs.update(existing)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -203,7 +203,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -211,7 +211,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -229,7 +229,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green.pk]),
+                pk_set={green.pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -237,7 +237,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green.pk]),
+                pk_set={green.pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -257,7 +257,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green.pk]),
+                pk_set={green.pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -265,7 +265,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green.pk]),
+                pk_set={green.pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -286,7 +286,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_remove',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -294,7 +294,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_remove',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -360,7 +360,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([red_pk]),
+                pk_set={red_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -368,7 +368,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([red_pk]),
+                pk_set={red_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -391,7 +391,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_remove',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -399,7 +399,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_remove',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([green_pk]),
+                pk_set={green_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -407,7 +407,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'pre_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([red_pk]),
+                pk_set={red_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default'),
@@ -415,7 +415,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 action=u'post_add',
                 instance=apple,
                 model=self.tag_model,
-                pk_set=set([red_pk]),
+                pk_set={red_pk},
                 reverse=False,
                 sender=self.taggeditem_model,
                 using='default')]
@@ -638,10 +638,10 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         with self.assertNumQueries(2):
             l = list(self.food_model.objects.prefetch_related('tags').all())
         with self.assertNumQueries(0):
-            foods = dict((f.name, set(t.name for t in f.tags.all())) for f in l)
+            foods = {f.name: {t.name for t in f.tags.all()} for f in l}
             self.assertEqual(foods, {
-                'orange': set(['2', '4']),
-                'apple': set(['1', '2'])
+                'orange': {'2', '4'},
+                'apple': {'1', '2'},
             })
 
     def test_internal_type_is_manytomany(self):
@@ -976,8 +976,7 @@ class InheritedPrefetchTests(TestCase):
         child = Child.objects.prefetch_related('tags').get()
         prefetch_tags = child.tags.all()
         self.assertEqual(4, prefetch_tags.count())
-        self.assertEqual(set([t.name for t in no_prefetch_tags]),
-                         set([t.name for t in prefetch_tags]))
+        self.assertEqual({t.name for t in no_prefetch_tags}, {t.name for t in prefetch_tags})
 
 
 class DjangoCheckTests(UnitTestCase):


### PR DESCRIPTION
Available since Python 2.7. Avoid some extra temporary lists and
function calls.