### PR TITLE
Allow Travis failures for Django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,13 @@ matrix:
       env: TOXENV=py35-1.11.x
     - python: 3.6
       env: TOXENV=py36-1.11.x
-    - python: 3.4
-      env: TOXENV=py34-master
     - python: 3.5
       env: TOXENV=py35-master
     - python: 3.6
       env: TOXENV=py36-master
   allow_failures:
-    - env: TOXENV=py{34,35,36}-master
+    - env: TOXENV=py35-master
+    - env: TOXENV=py36-master
 
 install:
   - pip install flake8 tox isort

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     {py27,py34,py35}-1.9.x
     {py27,py34,py35}-1.10.x
     {py27,py34,py35,py36}-1.11.x
-    {py34,py35,py36}-master
+    {py35,py36}-master
 
 [testenv]
 deps =


### PR DESCRIPTION
As Django master isn't fully stable, expect failures from time to time.