### PR TITLE
add renderer=None for django 2.1 compatibility

### DIFF
--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -8,7 +8,7 @@ from taggit.utils import edit_string_for_tags, parse_tags
 
 
 class TagWidget(forms.TextInput):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is not None and not isinstance(value, six.string_types):
             value = edit_string_for_tags([
                 o.tag for o in value.select_related("tag")])


### PR DESCRIPTION
Fixes TypeError: render() got an unexpected keyword argument 'renderer'