### PR TITLE
Add support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-1.11.x
     - python: 3.4
+      env: TOXENV=py34-2.0.x
+    - python: 3.5
+      env: TOXENV=py35-2.0.x
+    - python: 3.6
+      env: TOXENV=py36-2.0.x
+    - python: 3.4
       env: TOXENV=py34-master
     - python: 3.5
       env: TOXENV=py35-master

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py27,py34,py35}-1.9.x
     {py27,py34,py35}-1.10.x
     {py27,py34,py35,py36}-1.11.x
+    {py34,py35,py36}-2.0.x
     {py34,py35,py36}-master
 
 [testenv]
@@ -12,6 +13,7 @@ deps =
     1.9.x: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
     1.10.x: https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
     1.11.x: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
+    2.0.x: https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
     master: https://github.com/django/django/archive/master.tar.gz#egg=django
 commands =
     make develop test


### PR DESCRIPTION
Add Django 2.0 to the Travis and tox test matrix.

Add Django 2.0 to the list of trove classifiers.

Update `TaggableRel` for internal API differences of Django 2.0. Guard with a `VERSION` check where necessary.