### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27-1.8.x
-    - python: 3.3
-      env: TOXENV=py33-1.8.x
     - python: 3.4
       env: TOXENV=py34-1.8.x
     - python: 3.5

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+UNRELEASED
+~~~~~~~~~~
+ * Drop support for Python 3.3
+
 0.22.1 (2017-04-22)
 ~~~~~~~~~~~~~~~~~~~
  * Update spanish translation

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 Django>=1.8
 coverage
-pytest==3.2.5
+pytest
 pytest-cov
 pytest-django
 mock

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35}-1.8.x
+    {py27,py34,py35}-1.8.x
     {py27,py34,py35}-1.9.x
     {py27,py34,py35}-1.10.x
     {py27,py34,py35,py36}-1.11.x


### PR DESCRIPTION
Python 3.3 is EOL and no longer receiving bug fixes, including security fixes.

Python 3.3 is not supported by the latest pytest release, which is causing test failures on Travis and with tox.

https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23