### PR TITLE
Add renderer argument to TagWidget to match Django widget interface

### DIFF
--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -2,17 +2,22 @@ from __future__ import unicode_literals
 
 from django import forms
 from django.utils import six
+from django.utils.inspect import func_supports_parameter
 from django.utils.translation import ugettext as _
 
 from taggit.utils import edit_string_for_tags, parse_tags
 
 
 class TagWidget(forms.TextInput):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is not None and not isinstance(value, six.string_types):
             value = edit_string_for_tags([
                 o.tag for o in value.select_related("tag")])
-        return super(TagWidget, self).render(name, value, attrs)
+        kwargs = {}
+        if func_supports_parameter(super(TagWidget, self).render, 'renderer'):
+            # Django >= 1.11 supports the renderer argument.
+            kwargs['renderer'] = renderer
+        return super(TagWidget, self).render(name, value, attrs, **kwargs)
 
 
 class TagField(forms.CharField):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
-import warnings
 from unittest import TestCase as UnitTestCase
 
 import django
@@ -51,12 +49,7 @@ class BaseTaggingTest(object):
         return form_str
 
     def assertFormRenders(self, form, html):
-        # Django causes a DeprecationWarning on Python 3.3, 3.4
-        if (3, 3) <= sys.version_info < (3, 5):
-            with warnings.catch_warnings(record=True):
-                self.assertHTMLEqual(str(form), self._get_form_str(html))
-        else:
-            self.assertHTMLEqual(str(form), self._get_form_str(html))
+        self.assertHTMLEqual(str(form), self._get_form_str(html))
 
 
 # assertRaisesRegexp is deprecated in favour of assertRaisesRegex in recent versions of unittest,


### PR DESCRIPTION
Starting with Django 1.11, if a widget's `.render()` method does not have a renderer argument, a warning is issued of the form:

> RemovedInDjango21Warning: Add the `renderer` argument to the render() method of <class 'taggit.forms.TagWidget'>. It will be mandatory in Django 2.1.

Handle this argument to be future compatible and squelch the warning.

Added workaround for older Django versions as it is not always supported.

- Not supported: Django < 1.11
- Supported: Django 1.11 and 2.0
- Required: Django master

Tests against the master branch now pass.

For additional information see the Django release notes:

https://docs.djangoproject.com/en/1.11/releases/1.11/#id2

> The renderer argument is added to the `Widget.render()` method. Methods that don’t accept that argument will work through a deprecation period.

And the `Widget.render()` documentation:

https://docs.djangoproject.com/en/1.11/ref/forms/widgets/#django.forms.Widget.render

> Changed in Django 1.11:
>
> The renderer argument was added. Support for subclasses that don’t accept it will be removed in Django 2.1.