### PR TITLE
Trim trailing whitespace in docs/admin.txt

### DIFF
--- a/docs/admin.txt
+++ b/docs/admin.txt
@@ -14,7 +14,7 @@ of the :class:`TaggableManager` as a field::
 Including tags in :attr:`ModelAdmin.list_display`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-One important thing to note is that you *cannot* include a :class:`TaggableManager` 
+One important thing to note is that you *cannot* include a :class:`TaggableManager`
 in :attr:`ModelAdmin.list_display`. If you do you'll see an exception that looks
 like::
 
@@ -29,7 +29,7 @@ minimize queries::
 
     class MyModelAdmin(admin.ModelAdmin):
         list_display = ['tag_list']
-    
+
         def get_queryset(self, request):
             return super(MyModelAdmin, self).get_queryset(request).prefetch_related('tags')
 


### PR DESCRIPTION
Many editors are configured to automatically trim trailing whitespace. By removing trailing whitespace, helps avoid inadvertent whitespace changes in future diffs.