### PR TITLE
Fix TagWidget for Django 2.1

### DIFF
--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -8,11 +8,12 @@ from taggit.utils import edit_string_for_tags, parse_tags
 
 
 class TagWidget(forms.TextInput):
-    def render(self, name, value, attrs=None, renderer=None):
+    def format_value(self, value):
         if value is not None and not isinstance(value, six.string_types):
             value = edit_string_for_tags([
                 o.tag for o in value.select_related("tag")])
-        return super(TagWidget, self).render(name, value, attrs, renderer)
+
+        return super(TagWidget, self).format_value(value)
 
 
 class TagField(forms.CharField):


### PR DESCRIPTION
Proposed alternative fix to #505, which preserves the behaviour of the `renderer` kwarg.

`format_value` is a more suitable place for converting the value - this way we're sidestepping the need to deal with any current or future changes to Django's `render` logic.

(Unfortunately the Django <1.10 fallback code makes it pretty ugly, but hopefully that won't be there forever :-) )