### PR TITLE
Add pytest cache directory to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build/
 .cache/
 .coverage
 .eggs/
+.pytest_cache/


### PR DESCRIPTION
Since pytest 3.4.0, released 2018-01-30, the directory `.pytest_cache` is created when running tests.

https://docs.pytest.org/en/latest/changelog.html#pytest-3-4-0-2018-01-30