### PR TITLE
Add tox environments for Python 3.7 and Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,14 @@ matrix:
       env: TOXENV=py35-master
     - python: 3.6
       env: TOXENV=py36-master
+    - python: 3.7
+      env: TOXENV=py37-master
+      dist: xenial
+      sudo: true
   allow_failures:
     - env: TOXENV=py35-master
     - env: TOXENV=py36-master
+    - env: TOXENV=py37-master
 
 install:
   - pip install flake8 tox isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     py{27,34,35,36}-1.11.x
-    py{34,35,36}-2.0.x
-    py{35,36}-master
+    py{34,35,36,37}-2.0.x
+    py{35,36,37}-2.1.x
+    py{35,36,37}-master
 
 [testenv]
 deps =


### PR DESCRIPTION
Was missed in commit 6c02219d0d94060f06cb0ff5466d8dbe2caeea30.