### PR TITLE
Improve project linting (flake8 and isort)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 matrix:
   fast_finish: true
   include:
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
     - python: 2.7
       env: TOXENV=py27-1.11.x
     - python: 3.4
@@ -44,14 +46,10 @@ matrix:
     - env: TOXENV=py37-master
 
 install:
-  - pip install flake8 tox isort
-
-before_script:
-  - flake8 taggit
-  - python setup.py isort
+  - pip install tox
 
 script:
-  - tox -e $TOXENV
+  - tox
 
 after_success:
   - pip install codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,14 +5,20 @@ license-file = LICENSE
 universal = 1
 
 [flake8]
-# ignore=NONE
 max-line-length=119
 
 # E302: expected 2 blank lines, found 1 [E302]
 # E501: line too long
-ignore=E501,E302
-exclude = migrations,docs
+ignore = E501,E302
+exclude =
+    .tox
+    docs
+    migrations
 
 [isort]
-forced_separate=tests,taggit
-skip=migrations,.tox,docs
+forced_separate = tests,taggit
+not_skip = __init__.py
+skip =
+    .tox
+    docs
+    migrations

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,4 @@ setup(
     ],
     include_package_data=True,
     zip_safe=False,
-    setup_requires=[
-        'isort'
-    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,13 @@ commands =
 whitelist_externals = make
 
 [testenv:flake8]
+basepython = python3
 skip_install = true
-changedir = {toxinidir}
 deps = flake8
-commands = flake8 *.py taggit/ tests/
+commands = flake8
 
 [testenv:isort]
+basepython = python3
+skip_install = true
 deps = isort
-changedir = {toxinidir}
-commands = isort --recursive --check-only --diff taggit tests
+commands = isort --recursive --check-only --diff


### PR DESCRIPTION
- Normalize configuration to a consistent list of excluded directories
- Drop isort as a requirement of setup.py
- Always lint entire project
- Lint using Python3
- In Travis, only lint the project once, not for each environment