### PR TITLE
Fix TaggableManager in Admin example code

### DIFF
--- a/docs/admin.txt
+++ b/docs/admin.txt
@@ -8,7 +8,7 @@ If you are specifying :attr:`ModelAdmin.fieldsets`, include the name
 of the :class:`TaggableManager` as a field::
 
     fieldsets = (
-        (None, {'fields': ('tags')}),
+        (None, {'fields': ('tags',)}),
     )
 
 Including tags in :attr:`ModelAdmin.list_display`


### PR DESCRIPTION
The current code throws an error:

```
(admin.E008) The value of 'fieldsets[0][1]['fields']' must be a list or tuple.
```