### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: xenial
+sudo: false
 language: python
 cache: pip
-sudo: false
+
 matrix:
   fast_finish: true
   include:
@@ -22,24 +24,18 @@ matrix:
       env: TOXENV=py36-django20
     - python: 3.7
       env: TOXENV=py37-django20
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
     - python: 3.7
       env: TOXENV=py37-django21
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
-      dist: xenial
-      sudo: true
   allow_failures:
     - env: TOXENV=py35-djangomaster
     - env: TOXENV=py36-djangomaster


### PR DESCRIPTION
Allows using recent Python versions with the sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release