### PR TITLE
Adding slug convert option

### DIFF
--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -27,3 +27,15 @@ And then to any model you want tagging on do the following::
     If you want ``django-taggit`` to be **CASE INSENSITIVE** when looking up existing tags, you'll have to set to ``True`` the TAGGIT_CASE_INSENSITIVE setting (by default ``False``)::
 
       TAGGIT_CASE_INSENSITIVE = True
+
+.. note::
+
+    If you want ``django-taggit`` to be convert to slug **RAW UNICODE** when saving tags, you'll have to set to ``True`` the TAGGIT_NATIVE_UNICODE_SLUG setting (by default ``False``)::
+
+      TAGGIT_NATIVE_UNICODE_SLUG = False (Default)
+
+      >> 'seoul'
+
+      TAGGIT_NATIVE_UNICODE_SLUG = True
+
+      >> '서울'

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, models, router, transaction
@@ -68,7 +69,9 @@ class TagBase(models.Model):
             return super(TagBase, self).save(*args, **kwargs)
 
     def slugify(self, tag, i=None):
-        slug = slugify(unidecode(tag))
+        use_native_slug = getattr(settings, 'TAGGIT_NATIVE_UNICODE_SLUG', False)
+        slug = slugify(tag, allow_unicode=True) if use_native_slug else slugify(unidecode(tag))
+
         if i is not None:
             slug += "_%d" % i
         return slug


### PR DESCRIPTION
Unidecode translates non-English words, I have added an option to use the original language as a slug.

I tried to add a test, but adding non-English characters to the test code seemed to be a problem.